### PR TITLE
1.2: .editorconfig support, flags --hanging-indent and --convert-markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Options:
     indented code still needs to be properly formatted, but you also
     don't want comments to span 100+ characters, since that's less
     readable. By default this option is not set.
+  --hanging-indent=<n>
+    Sets the number of spaces to use for hanging indents, e.g. second
+    and subsequent lines in a bulleted list or kdoc blog tag.
+  --convert-markup
+    Convert unnecessary HTML tags like &lt; and &gt; into < and >
   --single-line-comments=<collapse | expand>
     With `collapse`, turns multi-line comments into a single line if it
     fits, and with `expand` it will always format commands with /** and
@@ -77,7 +82,7 @@ Options:
   @<filename>
     Read filenames from file.
 
-kdoc-formatter: Version 1.1.1
+kdoc-formatter: Version 1.1.2
 https://github.com/tnorbye/kdoc-formatter
 ```
 
@@ -85,12 +90,13 @@ IntelliJ Plugin Usage
 ---------------------
 Install the IDE plugin. Then move the caret to a KDoc comment and invoke
 Code > Reformat KDoc. You can configure a keyboard shortcut if you perform
-this action frequently. (Coming soon: ability to run this action on whole
-files and directories from within the IDE; currently use the command line
-as shown above to do this.)
+this action frequently. You can also select one or more files in the
+Project View and invoke the same action to format whole files.
 
 ![Screenshot](screenshot.png)
 
+The plugin is available from the JetBrains Marketplace at
+[https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter](https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter)
 
 Gradle Plugin Usage
 -------------------

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
+    apply from: "$rootDir/version.gradle"
+
     ext {
-        gradlePluginVersion = '7.0.0-alpha03'
+        gradlePluginVersion = '7.0.0-alpha04'
     }
 
     repositories {
@@ -72,7 +74,11 @@ task plugin {
     dependsOn ':ide-plugin:buildPlugin'
 }
 
+task all {
+    dependsOn 'clean', 'install', 'plugin', 'zip'
+}
+
 clean.doFirst {
-    delete "${rootDir}/../m2"
+    delete "${rootDir}/m2"
     delete "${rootDir}/gradle-plugin/build"
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "kdoc-formatter"
-version = "1.1.1"
+version = rootProject.ext.buildVersion
 
 application {
     mainClass = 'kdocformatter.cli.Main'
@@ -22,6 +22,7 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     implementation project(':library')
 }

--- a/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormatter.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormatter.kt
@@ -1,5 +1,6 @@
 package kdocformatter.cli
 
+import kdocformatter.EditorConfigs
 import kdocformatter.KDocFormatter
 import java.io.File
 
@@ -9,6 +10,10 @@ import java.io.File
  * light-weight lexical analysis to identify comments.
  */
 class KDocFileFormatter(private val options: KDocFileFormattingOptions) {
+    init {
+        EditorConfigs.root = options.formattingOptions
+    }
+
     /** Formats the given file or directory recursively */
     fun formatFile(file: File): Int {
         if (file.isDirectory) {
@@ -46,7 +51,8 @@ class KDocFileFormatter(private val options: KDocFileFormattingOptions) {
     fun reformatFile(file: File?, source: String): String {
         val sb = StringBuilder()
         val tokens = tokenizeKotlin(source)
-        val formatter = KDocFormatter(options.formattingOptions)
+        val formattingOptions = file?.let { EditorConfigs.getOptions(it) } ?: options.formattingOptions
+        val formatter = KDocFormatter(formattingOptions)
         val filter = options.filter
         var nextIsComment = false
         var start = 0

--- a/cli/src/main/kotlin/kdocformatter/cli/UnionFilter.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/UnionFilter.kt
@@ -1,0 +1,32 @@
+package kdocformatter.cli
+
+import java.io.File
+
+class UnionFilter(private val filters: List<RangeFilter>) : RangeFilter() {
+    override fun overlaps(file: File, source: String, startOffset: Int, endOffset: Int): Boolean {
+        for (filter in filters) {
+            if (filter.overlaps(file, source, startOffset, endOffset)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun includes(file: File): Boolean {
+        for (filter in filters) {
+            if (filter.includes(file)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun isEmpty(): Boolean {
+        for (filter in filters) {
+            if (!filter.isEmpty()) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
+++ b/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
@@ -88,14 +88,15 @@ class KDocFileFormatterTest {
     @Test
     fun testLineWidth() {
         // Perform in KDocFileFormatter test too to make sure we properly account for indent!
-        val source = """
+        val source =
+            """
             //3456789012345678901234567890 <- 30
             /**
              * This should fit on a single
              * And this should also fit!! 
              * And this should not!!!!!!!!! 
              */
-        """.trimIndent()
+            """.trimIndent()
         val reformatted = reformatFile(source, KDocFormattingOptions(30))
         assertEquals(
             """
@@ -134,7 +135,8 @@ class KDocFileFormatterTest {
             }
             """.trimIndent()
 
-        val diff = """
+        val diff =
+            """
             diff --git a/README.md b/README.md
             index c26815b..30a8dbb 100644
             --- README.md
@@ -154,11 +156,11 @@ class KDocFileFormatterTest {
             +++ README.md
             @@ -31,25 +31,29 @@ ${'$'} kdoc-formatter
              Usage: kdoc-formatter [options] file(s)
-        """.trimIndent()
+            """.trimIndent()
 
         val fileOptions = KDocFileFormattingOptions()
         val root = File("").canonicalFile
-        val file = File(root,"Test.kt")
+        val file = File(root, "Test.kt")
         fileOptions.filter = GitRangeFilter.create(root, diff)
         assertTrue(fileOptions.filter.includes(file))
         val reformatted = KDocFileFormatter(fileOptions).reformatFile(file, source.trim())

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
+    apply from: "$rootDir/../version.gradle"
+
     ext {
-        gradlePluginVersion = '7.0.0-alpha03'
+        gradlePluginVersion = '7.0.0-alpha04'
     }
 
     repositories {
@@ -23,7 +25,7 @@ plugins {
 
 // https://issues.sonatype.org/browse/OSSRH-63191
 group = "com.github.tnorbye.kdoc-formatter"
-version = "1.1.1"
+version = rootProject.ext.buildVersion
 
 repositories {
     google()
@@ -83,7 +85,7 @@ publishing {
             groupId "com.github.tnorbye.kdoc-formatter"
             artifactId "kdoc-formatter"
             //version project.version
-            version "1.1.1"
+            version rootProject.ext.buildVersion
         }
     }
 }
@@ -99,4 +101,8 @@ publishing {
 
 clean.doFirst {
     delete "${rootDir}/../m2"
+}
+
+task all {
+    dependsOn 'clean', 'publish'
 }

--- a/ide-plugin/build.gradle
+++ b/ide-plugin/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "kdoc-formatter"
-version = "1.1.1"
+version = rootProject.ext.buildVersion
 
 repositories {
     google()
@@ -24,11 +24,17 @@ dependencies {
 intellij {
     version '2020.3'
     pluginName = "kdoc-formatter-ide-plugin"
+    updateSinceUntilBuild = false
 }
 
 patchPluginXml {
     changeNotes """
-      First version!"""
+1.2: Basic support for <code>.editorconfig</code> files.
+<p/>
+1.1: Support for setting maximum comment width (capped by the maximum line width).
+<p/>
+1.0: Initial version
+"""
 }
 
 test {

--- a/ide-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ide-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,26 +1,35 @@
 <idea-plugin>
   <id>org.norbye.tor.kdocformatter</id>
   <name>Kotlin KDoc Formatter</name>
-  <version>1.1.1</version>
   <vendor email="tor.norbye@gmail.com" url="https://github.com/tnorbye/kdoc-formatter">Tor Norbye</vendor>
 
   <description><![CDATA[
       This plugin lets you reformat KDoc text -- meaning that it will reformat the
       text and flowing the text up to the line width, collapsing comments that
       fit on a single line, indenting text within a block tag, etc.
+      <p>
 
       There are two usage modes. First, it can reformat the current comment
       around the caret position. Open a Kotlin file, navigate to the KDoc
       comment (e.g. <code>/** My Comment */</code>), and then invoke Code | Reformat KDoc.
+      <p>
 
       The second mode lets you reformat all the comments in one or more Kotlin
       source files. For this, navigate to the Projects view and select one or
       more source files, and again invoke Code | Reformat KDoc.
+      <p>
 
       More details about the features can be found at
       <a href="https://github.com/tnorbye/kdoc-formatter#kdoc-formatter">
       https://github.com/tnorbye/kdoc-formatter#kdoc-formatter
       </a>
+      <p>
+      You can create a shortcut and assign it to this action if you use it
+      frequently. On Mac for example, open the Preferences dialog, search for
+      Keymap, then in the Keymap search field search for "KDoc", and double click
+      on the action to choose "Add Shortcut", then choose the shortcut you want.
+      For me, formatting the whole file is assigned to Cmd-Opt-L, so I've assigned
+      Reformat KDoc to Cmd-Shift-L.
     ]]></description>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "kdoc-formatter"
-version = "1.1.1"
+version = rootProject.ext.buildVersion
 
 repositories {
     google()

--- a/library/src/main/kotlin/kdocformatter/EditorConfigs.kt
+++ b/library/src/main/kotlin/kdocformatter/EditorConfigs.kt
@@ -1,0 +1,234 @@
+package kdocformatter
+
+import java.io.File
+import java.util.Locale
+import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
+
+/**
+ * Basic support for [.editorconfig] files
+ * (http://https://editorconfig.org/).
+ *
+ * This will construct [KDocFormattingOptions] applicable for
+ * a given file. The [KDocFormattingOptions.maxLineWidth]
+ * property is initialized from the [.editorconfig] property
+ * `max_line_length` applicable to Kotlin source files, and the
+ * [KDocFormattingOptions.maxCommentWidth] is initialized from the
+ * property `max_line_length` applicable to Markdown source files (but
+ * **not** inherited from non-Markdown specific declarations such as
+ * [*].]
+ *
+ * We're processing it ourselves here instead of using one of the
+ * available editorconfig libraries on GitHub because of that special
+ * handling of markdown settings where we want to consult values without
+ * inheritance.
+ */
+object EditorConfigs {
+    var root: KDocFormattingOptions? = null
+        set(value) {
+            dirToConfig.clear()
+            field = value
+        }
+    private val dirToConfig = mutableMapOf<File, EditorConfig>()
+
+    fun getOptions(file: File): KDocFormattingOptions {
+        val parent = file.parentFile ?: return root ?: KDocFormattingOptions()
+        return getConfig(parent)?.getOptions() ?: root ?: KDocFormattingOptions()
+    }
+
+    @Suppress("FileComparisons")
+    private fun getConfig(dir: File?): EditorConfig? {
+        dir ?: return null
+
+        val existing = dirToConfig[dir]
+        if (existing != null) {
+            return if (existing !== EditorConfig.NONE) existing else null
+        }
+
+        val configFile = findEditorConfigFile(dir) ?: run {
+            dirToConfig[dir] = EditorConfig.NONE
+
+            var curr = dir.parentFile
+            while (true) {
+                dirToConfig[curr] = EditorConfig.NONE
+                curr = curr.parentFile ?: break
+            }
+
+            return null
+        }
+
+        val configFolder = configFile.parentFile
+        val parentConfigFolder = configFolder?.parentFile
+        val parent = getConfig(parentConfigFolder)
+        val config = EditorConfig.createEditorConfig(configFile, parent)
+        dirToConfig[dir] = config
+
+        if (configFolder != dir) {
+            var curr: File = dir
+            while (true) {
+                if (curr == configFolder) {
+                    break
+                } else {
+                    dirToConfig[curr] = config
+                }
+                curr = curr.parentFile ?: break
+            }
+        }
+
+        return config
+    }
+
+    private fun findEditorConfigFile(fromDir: File): File? {
+        var dir = fromDir
+        while (true) {
+            val file = File(dir, ".editorconfig")
+            if (file.isFile) {
+                return file
+            }
+            dir = dir.parentFile ?: return null
+        }
+    }
+
+    class EditorConfig private constructor(
+        private val root: Boolean,
+        private val file: File,
+        private val parent: EditorConfig?,
+        private val sections: List<SectionMap>
+    ) {
+        private data class SectionMap(val section: String, val map: Map<String, String>)
+
+        private var options: KDocFormattingOptions? = null
+
+        fun getOptions(): KDocFormattingOptions {
+            return options ?: computeOptions().also { options = it }
+        }
+
+        fun getValue(key: String, eligibleSection: String, includeRoot: Boolean = true): Any? {
+            var value: String? = null
+            for (section in sections) {
+                val name = section.section
+                if (includeRoot && name == "[*]" || name.contains(eligibleSection)) {
+                    // last applicable value wins
+                    section.map[key]?.let { value = it }
+                }
+            }
+
+            if (value == null && !root) {
+                return parent?.getValue(key, eligibleSection, includeRoot)
+            }
+
+            return value
+        }
+
+        private fun computeOptions(): KDocFormattingOptions {
+            val options = (if (!root) parent?.getOptions()?.copy() else null)
+                ?: EditorConfigs.root?.copy()
+                ?: KDocFormattingOptions()
+
+            getValue("max_line_length", "*.kt")?.let { stringValue ->
+                if (stringValue == "unset")
+                    EditorConfigs.root?.maxLineWidth?.let { options.maxLineWidth = it }
+                else
+                    (stringValue as? String)?.toIntOrNull()?.let { value ->
+                        options.maxLineWidth = value
+                    }
+            }
+
+            getValue("max_line_length", "*.md", false)?.let { stringValue ->
+                if (stringValue == "unset")
+                    EditorConfigs.root?.maxCommentWidth?.let { options.maxCommentWidth = it }
+                else
+                    (stringValue as? String)?.toIntOrNull()?.let { value ->
+                        options.maxCommentWidth = value
+                    }
+            }
+
+            getValue("indent_size", "*.kt")?.let { stringValue ->
+                if (stringValue == "unset")
+                    EditorConfigs.root?.hangingIndent?.let { options.hangingIndent = it }
+                else
+                    (stringValue as? String)?.toIntOrNull()?.let { value ->
+                        options.hangingIndent = value
+                    }
+            }
+
+            getValue("tab_width", "*.kt")?.let { stringValue ->
+                if (stringValue == "unset")
+                    EditorConfigs.root?.tabWidth?.let { options.tabWidth = it }
+                else
+                    (stringValue as? String)?.toIntOrNull()?.let { value ->
+                        options.tabWidth = value
+                    }
+            }
+
+            getValue("kdoc_formatter_doc_do_not_wrap_if_one_line", "*.kt")?.let { stringValue ->
+                if (stringValue == "unset")
+                    EditorConfigs.root?.collapseSingleLine?.let { options.collapseSingleLine = it }
+                else
+                    (stringValue as? String)?.toBoolean()?.let { value ->
+                        options.collapseSingleLine = !value
+                    }
+            }
+
+            return options
+        }
+
+        override fun toString(): String {
+            return file.toString()
+        }
+
+        companion object {
+            val NONE = EditorConfig(true, File(""), null, emptyList())
+
+            // If root -- no need to keep going
+            fun createEditorConfig(config: File, parent: EditorConfig?): EditorConfig {
+                // Maybe have a default flag, e.g. --default-line-width
+                val sections = ArrayList<SectionMap>()
+                var section: SectionMap? = null
+                var map = HashMap<String, String>()
+                var root = false
+
+                val lines = config.readLines()
+                for (line in lines) {
+                    if (line.startsWith("#") || line.startsWith(";") || line.isBlank()) {
+                        continue
+                    }
+                    if (line.startsWith("[")) {
+                        val globs = line
+                            .removePrefix("[").removeSuffix("]")
+                            .removePrefix("{").removeSuffix("}")
+                            .split(",")
+
+                        if (globs.any { it == "*" || it == "*.kt" || it == "*.kts" || it == "*.md" }) {
+                            map = HashMap()
+                            section = SectionMap(line, map)
+                            sections.add(section)
+                        } else {
+                            section = null
+                        }
+                    } else {
+                        val eq = line.indexOf('=')
+                        val key = line.substring(0, eq).trim().toLowerCase(Locale.US)
+                        if (key == "root") {
+                            root = line.substring(eq + 1).trim().toBoolean()
+                        } else when (key) {
+                            "max_line_length",
+                            "indent_size",
+                            "tab_width",
+                            "kdoc_formatter_doc_do_not_wrap_if_one_line",
+                            "ij_continuation_indent_size",
+                            "ij_java_doc_do_not_wrap_if_one_line",
+                            "ij_kotlin_align_multiline_parameters" ->
+                                if (section != null) {
+                                    val value = line.substring(eq + 1).trim()
+                                    map[key] = value
+                                }
+                        }
+                    }
+                }
+
+                return EditorConfig(root, config, parent, sections)
+            }
+        }
+    }
+}

--- a/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
@@ -141,13 +141,6 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
                     s.startsWith("</pre>", ignoreCase = true)
                 }
                 continue
-            } else if (lineWithoutIndentation.isListItem() || lineWithoutIndentation.isKDocTag()) {
-                rawText.appendFirstNewline()
-                i = addLines(lines, i - 1, includeEnd = false, preformatted = false) { _, w, s ->
-                    s.isBlank() || w.isListItem() || s.isKDocTag()
-                }
-                rawText.append('\n')
-                continue
             } else if (lineWithIndentation.startsWith("    ")) { // markdown preformatted text
                 i = addLines(lines, i - 1, includeEnd = true, preformatted = true) { _, _, s ->
                     !s.startsWith(" ")
@@ -155,6 +148,16 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
                 rawText.append('\n')
                 continue
             }
+
+            if (lineWithoutIndentation.isListItem() || lineWithoutIndentation.isKDocTag()) {
+                rawText.appendFirstNewline()
+                i = addLines(lines, i - 1, includeEnd = false, preformatted = false) { _, w, s ->
+                    s.isBlank() || w.isListItem() || s.isKDocTag()
+                }
+                rawText.append('\n')
+                continue
+            }
+
             if (lineWithoutIndentation.isEmpty()) {
                 if (rawText.isNotEmpty()) {
                     rawText.append('\n')
@@ -174,11 +177,12 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
             if (line.isBlank()) {
                 continue
             }
-            val paragraph = Paragraph(line)
+
+            val paragraph = Paragraph(line, options)
             paragraphs.add(paragraph)
         }
 
-        return ParagraphList(paragraphs)
+        return ParagraphList(paragraphs, options)
     }
 
     companion object {

--- a/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
@@ -23,10 +23,16 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
     var collapseSpaces: Boolean = true
 
     /**
-     * Whether to have hanging indents in numbered lists and after block
-     * tags
+     * Whether to convert basic markup like **bold** into **bold**, <
+     * into <, etc.
      */
-    var hangingIndents: Boolean = true
+    var convertMarkup: Boolean = true
+
+    /**
+     * How many spaces to use for hanging indents in numbered lists and
+     * after block tags
+     */
+    var hangingIndent: Int = 4
 
     /**
      * Don't format with tabs! (See
@@ -35,4 +41,16 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
      * But if you do, this is the tab width.
      */
     var tabWidth: Int = 8
+
+    /** Creates a copy of this formatting object */
+    fun copy(): KDocFormattingOptions {
+        val copy = KDocFormattingOptions()
+        copy.maxLineWidth = maxLineWidth
+        copy.maxCommentWidth = maxCommentWidth
+        copy.collapseSingleLine = collapseSingleLine
+        copy.collapseSpaces = collapseSpaces
+        copy.hangingIndent = hangingIndent
+        copy.tabWidth = tabWidth
+        return copy
+    }
 }

--- a/library/src/main/kotlin/kdocformatter/Paragraph.kt
+++ b/library/src/main/kotlin/kdocformatter/Paragraph.kt
@@ -2,13 +2,13 @@ package kdocformatter
 
 import kotlin.math.min
 
-class Paragraph(val text: String) {
+class Paragraph(var text: String, options: KDocFormattingOptions) {
     fun isBlockTag() = text.isKDocTag()
     fun isListItem() = listItem
     var separate = true
     val listItem = text.isListItem()
     var preformatted = text.startsWith("    ")
-    var hangingIndent = if (isBlockTag()) "    " else ""
+    var hangingIndent = if (isBlockTag()) getIndent(options.hangingIndent) else ""
     override fun toString(): String = text
 
     fun reflow(maxLineWidth: Int, options: KDocFormattingOptions): List<String> {
@@ -187,7 +187,7 @@ class Paragraph(val text: String) {
         while (offset < text.length) {
             val isBeginning = offset == 0
             var width = lineWidth
-            if (options.hangingIndents && (isBlockTag || isListItem) && !isBeginning) {
+            if (options.hangingIndent > 0 && (isBlockTag || isListItem) && !isBeginning) {
                 width -= getIndentSize(hangingIndent, options)
             }
             while (offset < text.length && text[offset].isWhitespace()) {

--- a/library/src/main/kotlin/kdocformatter/ParagraphList.kt
+++ b/library/src/main/kotlin/kdocformatter/ParagraphList.kt
@@ -1,6 +1,9 @@
 package kdocformatter
 
-class ParagraphList(val paragraphs: List<Paragraph>) : Iterable<Paragraph> {
+class ParagraphList(
+    private val paragraphs: List<Paragraph>,
+    private val options: KDocFormattingOptions
+) : Iterable<Paragraph> {
     init {
         var prev: Paragraph? = null
         var inPreformat = false
@@ -29,6 +32,22 @@ class ParagraphList(val paragraphs: List<Paragraph>) : Iterable<Paragraph> {
                 paragraph.preformatted = true
                 inPreformat = false
             }
+
+            if (!inPreformat) {
+                var cleaned = paragraph.text
+                if (options.convertMarkup && (cleaned.contains("<") || cleaned.contains(">"))) {
+                    cleaned = cleaned.replace("<b>", "**").replace("</b>", "**")
+                        .replace("<i>", "*").replace("</i>", "*")
+                }
+                if (options.convertMarkup && cleaned.contains("&")) {
+                    cleaned = cleaned.replace("&lt;", "<").replace("&LT;", "<")
+                        // TODO: <b> and </b> ?
+                        .replace("&gt;", ">").replace("&GT;", ">")
+                }
+
+                paragraph.text = cleaned
+            }
+
             prev = paragraph
         }
     }

--- a/library/src/main/kotlin/kdocformatter/Version.kt
+++ b/library/src/main/kotlin/kdocformatter/Version.kt
@@ -1,0 +1,16 @@
+package kdocformatter
+
+import java.io.BufferedInputStream
+import java.util.Properties
+
+object Version {
+    var versionString: String
+    init {
+        val properties = Properties()
+        val stream = Version::class.java.getResourceAsStream("/version.properties")
+        BufferedInputStream(stream).use { buffered ->
+            properties.load(buffered)
+        }
+        versionString = properties.getProperty("buildVersion")
+    }
+}

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,0 +1,2 @@
+# Release version definition
+buildVersion = 1.1.2

--- a/library/src/test/kotlin/kdocformatter/EditorConfigsTest.kt
+++ b/library/src/test/kotlin/kdocformatter/EditorConfigsTest.kt
@@ -1,0 +1,130 @@
+package kdocformatter
+
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.File
+import org.junit.jupiter.api.io.TempDir
+
+class EditorConfigsTest {
+    companion object {
+        @TempDir
+        @JvmField
+        var temporaryFolder: File? = null
+    }
+
+    class ConfigFile(val relativePath: String, @Language("EditorConfig") val contents: String)
+
+    private fun createFileTree(vararg files: ConfigFile): File {
+        val root = temporaryFolder!!
+        root.deleteRecursively()
+        for (file in files) {
+            val target = File(root, file.relativePath)
+            target.parentFile?.mkdirs()
+            target.writeText(file.contents)
+        }
+        return root
+    }
+
+    @Test
+    fun testBasics() {
+        EditorConfigs.root = null
+        val fileTree = createFileTree(
+            ConfigFile(
+                "root/.editorconfig",
+                ";comment\nroot = true\n[*]\nmax_line_length=150\ntab_width = 10"
+            ),
+            ConfigFile(
+                "root/sub1/sub2/.editorconfig",
+                "[*]\nindent_size = 6\n[*.md]\nmax_line_length = 40\n[*.kt]\nmax_line_length = 60"
+            ),
+            ConfigFile(
+                "root/sub1/sub3/.editorconfig",
+                "[*]\nindent_size = 6\n[{*.java,*.kt}]\nmax_line_length=120\n[*.md]\nmax_line_length = 80\n; max_line_length = 110"
+            )
+        )
+        val file1 = File(fileTree, "root/sub1/sub2/sub3/sub4/foo.kt")
+        val options1 = EditorConfigs.getOptions(file1)
+        assertEquals(60, options1.maxLineWidth)
+        assertEquals(40, options1.maxCommentWidth)
+
+        val file2 = File(fileTree, "root/sub1/sub2/foo.kt")
+        val options2 = EditorConfigs.getOptions(file2)
+        assertEquals(60, options2.maxLineWidth)
+        assertEquals(40, options2.maxCommentWidth)
+
+        val file3 = File(fileTree, "root/sub1/foo.kt")
+        val options3 = EditorConfigs.getOptions(file3)
+        assertEquals(150, options3.maxLineWidth)
+        assertEquals(KDocFormattingOptions().maxCommentWidth, options3.maxCommentWidth)
+
+        val file4 = File(fileTree, "root/sub1/sub3/foo.kt")
+        val options4 = EditorConfigs.getOptions(file4)
+        assertEquals(120, options4.maxLineWidth)
+        assertEquals(80, options4.maxCommentWidth)
+        assertEquals(6, options4.hangingIndent)
+    }
+
+    @Test
+    fun testFallback() {
+        val fallback = KDocFormattingOptions()
+        fallback.maxLineWidth = 80
+        fallback.maxCommentWidth = 50
+        EditorConfigs.root = fallback
+
+        val fileTree = createFileTree(
+            ConfigFile(
+                "root/.editorconfig",
+                "root = true\n[*]\nmax_line_length=150\ntab_width = 10"
+            ),
+        )
+        val file1 = File(fileTree, "root/sub1/sub2/sub3/sub4/foo.kt")
+        val options1 = EditorConfigs.getOptions(file1)
+        assertEquals(150, options1.maxLineWidth)
+        assertEquals(50, options1.maxCommentWidth)
+    }
+
+    @Test
+    fun testUnset() {
+        val fallback = KDocFormattingOptions()
+        fallback.maxLineWidth = 80
+        fallback.maxCommentWidth = 50
+        EditorConfigs.root = fallback
+
+        val fileTree = createFileTree(
+            ConfigFile(
+                "root/.editorconfig",
+                "root = true\n[*]\nmax_line_length=150\ntab_width = 10"
+            ),
+            ConfigFile(
+                "root/sub1/sub2/.editorconfig",
+                "[*]\nindent_size = 6\n[*.kt]\nmax_line_length = unset"
+            ),
+        )
+        val file = File(fileTree, "root/sub1/sub2/sub3/sub4/foo.kt")
+        val options = EditorConfigs.getOptions(file)
+        assertEquals(80, options.maxLineWidth) // go to fallback since set to unset in closest editor config
+    }
+
+    @Test
+    fun testStopAtRoot() {
+        val fallback = KDocFormattingOptions()
+        fallback.maxLineWidth = 80
+        fallback.maxCommentWidth = 50
+        EditorConfigs.root = fallback
+
+        val fileTree = createFileTree(
+            ConfigFile(
+                "root/.editorconfig",
+                "root = true\n[*]\nmax_line_length=150\ntab_width = 10"
+            ),
+            ConfigFile(
+                "root/sub1/sub2/.editorconfig",
+                "root = true\n[*]\nindent_size = 6\n"
+            ),
+        )
+        val file = File(fileTree, "root/sub1/sub2/sub3/sub4/foo.kt")
+        val options = EditorConfigs.getOptions(file)
+        assertEquals(80, options.maxLineWidth) // go to fallback since stops at local root
+    }
+}

--- a/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
@@ -66,16 +66,18 @@ class KDocFormatterTest {
 
     @Test
     fun testWithOffset() {
-        val source = """
+        val source =
+            """
             /** Returns whether lint should check all warnings,
              * including those off by default */
-        """.trimIndent()
-        val reformatted = """
+            """.trimIndent()
+        val reformatted =
+            """
             /**
              * Returns whether lint should check all warnings, including those
              * off by default
              */
-        """.trimIndent()
+            """.trimIndent()
         checkFormatter(
             source,
             KDocFormattingOptions(72),
@@ -198,13 +200,14 @@ class KDocFormatterTest {
     @Test
     fun testLineWidth1() {
         // Perform in KDocFileFormatter test too to make sure we properly account for indent!
-        val source = """
+        val source =
+            """
             /**
              * 89 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789
              *
              *   10        20        30        40        50        60        70        80
              */
-        """.trimIndent()
+            """.trimIndent()
         checkFormatter(
             source,
             KDocFormattingOptions(72),
@@ -263,6 +266,8 @@ class KDocFormatterTest {
 
     @Test
     fun testBlockTagsHangingIndents() {
+        val options = KDocFormattingOptions(40)
+        options.hangingIndent = 6
         checkFormatter(
             """
             /**
@@ -276,7 +281,7 @@ class KDocFormatterTest {
              * @return the list of class entries, never null.
              */
             """.trimIndent(),
-            KDocFormattingOptions(40),
+            options,
             """
             /**
              * Creates a list of class entries
@@ -284,18 +289,19 @@ class KDocFormatterTest {
              * specific set of files within it.
              *
              * @param client the client to
-             *     report errors to and
-             *     to use to read files
+             *       report errors to and
+             *       to use to read files
              * @param classFiles the specific
-             *     set of class files to look
-             *     for
+             *       set of class files to look
+             *       for
              * @param classFolders the list of
-             *     class folders to look in (to
-             *     determine the package root)
+             *       class folders to look
+             *       in (to determine
+             *       the package root)
              * @param sort if true, sort the
-             *     results
+             *       results
              * @return the list of class
-             *     entries, never null.
+             *       entries, never null.
              */
             """.trimIndent()
         )

--- a/version.gradle
+++ b/version.gradle
@@ -1,0 +1,19 @@
+Properties properties = new Properties()
+File versionRootDir = rootDir
+String relativeVersionPath = "library/src/main/resources/version.properties"
+File versionProperties = new File(versionRootDir, relativeVersionPath)
+
+project.ext['versionProperties'] = versionProperties
+
+while (!versionProperties.exists() && versionRootDir.parentFile != null &&
+        versionRootDir.parentFile.exists()) {
+    versionRootDir = versionRootDir.parentFile
+    versionProperties = new File(versionRootDir, relativeVersionPath)
+}
+
+versionProperties.withReader { properties.load(it) }
+
+for (name in properties.stringPropertyNames()) {
+    String version = properties.getProperty(name)
+    project.ext[name] = version
+}


### PR DESCRIPTION
Adds basic support for .editorconfig files, both from IDE and from
command line tool. Also adds flags to configure the hanging indent,
and a new flag for converting HTML tags that are not necessary.

Also parameterizes the version number such that it's only configured
in one place.