### PR TITLE
1.3.1: Bug fixes, TODO item handling and add missing punctuation feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,26 +1,39 @@
+Version 1.3.1
+=============
+
+Fix a few bugs around markup conversion not producing the right
+number of blank lines for a <p>, as well as add a few more prefixes
+as non-breakable (e.g. if you have an em dash in your sentence --
+like this -- we don't want the "--" to be placed at the beginning of
+a line.)
+
+Also adds an --add-punctuation command line flag and IDE setting to
+optionally add closing periods on capitalized paragraphs at the end
+of the comment.
+
+Special cases TODO: comments (placing them in a block by themselves
+and using hanging indents).
+
 Version 1.3
 ===========
 
 This version contains the following improvements:
-
-* Many improves to the markdown handling, such as quoted
-  blocks, headers, list continuations, etc.
-
+* Many improves to the markdown handling, such as quoted blocks,
+  headers, list continuations, etc.
 * Markup conversion, which until this point could convert inline tags
-  such as <b>bold</b> into **bold**, etc, now handles many block level
-  tags too, such as <p>, <h1>, etc.
-
-* The IDE plugin can now also reformat line comments under the
-  caret. (This is opt-in via options.)
+  such as **bold** into **bold**, etc, now handles
+  many block level tags too, such as <p>, <h1>, etc.
+* The IDE plugin can now also reformat line comments under the caret.
+  (This is opt-in via options.)
 
 Version 1.2
 ===========
 
 This version adds a settings panel to the IDE plugin where you can
 configure whether the plugin will alternate formatting modes on
-repeated invocation, as well as whether single line comments should be
-collapsed and whether to convert markup like bold to bold. (Note that
-line lengths will just use the IDE code style settings or
+repeated invocation, as well as whether single line comments should
+be collapsed and whether to convert markup like bold to bold. (Note
+that line lengths will just use the IDE code style settings or
 .editorconfig files).
 
 It also improves the code which preserves the caret across formatting
@@ -46,39 +59,29 @@ Version 1.1
 ===========
 
 This version adds support for --max-comment-width, and for the Gradle
-plugin to be able to supply options (via kdocformatter.options =
-"--max-line-width=100 --max-comment-width=72" etc.) It changes the
-Gradle plugin group id (since the previous one was rejected by
-Sonatype) and tweaks a few minor things.
+plugin to be able to supply options (via kdocformatter.options
+= "--max-line-width=100 --max-comment-width=72" etc.) It
+changes the Gradle plugin group id (since the previous one
+was rejected by Sonatype) and tweaks a few minor things.
 
 Version 1.0
 ===========
-
 * Command line script which can recursively format a whole source
   folder
-
 * IDE plugin to format selected files or current comment. Preserves
   caret position in the current comment.
-
 * Gradle plugin to format the source folders in the current project.
-
 * Block tags (like @param) are separated out from the main text, and
-  subsequent lines are indented. Blank spaces between doc tags are
-  removed. Preformatted text (indented 4 spaces or more) is left
-  alone.
-
+  subsequent lines are indented. Blank spaces
+  between doc tags are removed. Preformatted text
+  (indented 4 spaces or more) is left alone.
 * Can be run in a mode where it only reformats comments that were
-  touched by the current git HEAD commit, or the currently staged
-  files. Can also be passed specific line ranges to limit formatting
-  to.
-
+  touched by the current git HEAD commit, or the
+  currently staged files. Can also be passed
+  specific line ranges to limit formatting to.
 * Multiline comments that would fit on a single line are converted to
   a single line comment (configurable via options)
-
 * Adds hanging indents for ordered and unordered indents.
-
-* Cleans up the double spaces left by the IntelliJ "Convert to Kotlin"
-  action right before the closing comment token.
-
+* Cleans up the double spaces left by the IntelliJ "Convert to
+  Kotlin" action right before the closing comment token.
 * Removes trailing spaces.
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 KDoc Formatter
 ==============
 
-Reformats Kotlin KDoc comments, reflowing text and other cleanup, both
-via IDE plugin and command line utility.
+Reformats Kotlin KDoc comments, reflowing text and other cleanup,
+both via IDE plugin and command line utility.
 
 This tool reflows comments in KDoc; either on a file or recursively
 over nested folders, as well as an IntelliJ IDE plugin where you can
@@ -10,54 +10,43 @@ reflow the current comment around the cursor.
 
 Features
 --------
-
 * Reflow using optimal instead of greedy algorithm (though in the IDE
-  plugin you can turn on alternate formatting and invoking the action
-  repeatedly alternates between the two modes.)
-
+  plugin you can turn on alternate formatting and invoking
+  the action repeatedly alternates between the two modes.)
 * Command line script which can recursively format a whole source
   folder.
-
 * IDE plugin to format selected files or current comment. Preserves
   caret position in the current comment.
-
 * Gradle plugin to format the source folders in the current project.
-
 * Block tags (like @param) are separated out from the main text, and
-  subsequent lines are indented. Blank spaces between doc tags
-  are removed. Preformatted text (indented 4 spaces or more) is left
-  alone.
-
+  subsequent lines are indented. Blank spaces
+  between doc tags are removed. Preformatted text
+  (indented 4 spaces or more) is left alone.
 * Can be run in a mode where it only reformats comments that were
-  touched by the current git HEAD commit, or the currently staged
-  files. Can also be passed specific line ranges to limit formatting
-  to.
-
+  touched by the current git HEAD commit, or the
+  currently staged files. Can also be passed
+  specific line ranges to limit formatting to.
 * Multiline comments that would fit on a single line are converted to
   a single line comment (configurable via options)
-
 * Adds hanging indents for ordered and unordered indents.
-
-* Cleans up the double spaces left by the IntelliJ "Convert to Kotlin"
-  action right before the closing comment token.
-
+* Cleans up the double spaces left by the IntelliJ "Convert to
+  Kotlin" action right before the closing comment token.
 * Removes trailing spaces.
-
 * Can optionally convert various remaining HTML tags in the comments
-  to the corresponding KDoc/markdown text. For example, <b>bold</b> is
-  converted into **bold**, <p> is converted to a blank line,
+  to the corresponding KDoc/markdown text. For example, **bold**
+  is converted into **bold**, <p> is converted to a blank line,
   <h1>Heading</h1> is converted into # Heading, and so on.
-
 * Support for .editorconfig configuration files to automatically pick
   up line widths. It will normally use the line width configured for
   Kotlin files, but, if Markdown (.md) files are also configured, it
-  will use that width as the maximum comment width. This allows you to
-  have code line widths of for example 140 but limit comments to 70
-  characters (possibly indented). For code, avoiding line breaking is
-  helpful, but for text, shorter lines are better for reading.
+  will use that width as the maximum comment width. This allows you
+  to have code line widths of for example 140 but limit comments to
+  70 characters (possibly indented). For code, avoiding line breaking
+  is helpful, but for text, shorter lines are better for reading.
 
 Command Usage
 -------------
+
 ```
 $ kdoc-formatter
 Usage: kdoc-formatter [options] file(s)
@@ -89,6 +78,9 @@ Options:
   --lines <start:end>, --line <start>
     Line range(s) to format, like 5:10 (1-based; default is all). Can be
     specified multiple times.
+  --greedy
+    Instead of the optimal line breaking normally used by kdoc-formatter,
+    do greedy line breaking instead
   --dry-run, -n
     Prints the paths of the files whose contents would change if the
     formatter were run normally.
@@ -99,39 +91,38 @@ Options:
   @<filename>
     Read filenames from file.
 
-kdoc-formatter: Version 1.3
+kdoc-formatter: Version 1.3.1
 https://github.com/tnorbye/kdoc-formatter
 ```
 
 IntelliJ Plugin Usage
 ---------------------
-Install the IDE plugin. Then move the caret to a KDoc comment and invoke
-Code > Reformat KDoc. You can configure a keyboard shortcut if you perform
-this action frequently (go to Preferences, search for Keymap, and then
-in the Keymap search field look for "KDoc", and then double click and
-choose Add Keyboard Shortcut. 
+Install the IDE plugin. Then move the caret to a KDoc comment and
+invoke Code > Reformat KDoc. You can configure a keyboard shortcut
+if you perform this action frequently (go to Preferences, search for
+Keymap, and then in the Keymap search field look for "KDoc", and then
+double click and choose Add Keyboard Shortcut.
 
-You can also select one or more files in the
-Project View and invoke the same action to format whole files.
+You can also select one or more files in the Project View and invoke
+the same action to format whole files.
 
 ![Screenshot](screenshot.png)
 
-Finally, you can configure various options in the Settings panel.
-The line length settings are inherited from the IDE code style or
-from the .editorconfig files, if any. However, you can turn on
-"alternate" mode where invoking the action repeatedly will toggle
-between normal formatting and alternate formatting each time you
-invoke it. For a short comment that means toggling between a
-multi-line and a single-line comment. But for a longer comment,
-it will toggle between optimal line breaking (the default) and
-greedy line breaking, which can look better for short paragraphs.
+Finally, you can configure various options in the Settings panel. The
+line length settings are inherited from the IDE code style or from
+the .editorconfig files, if any. However, you can turn on "alternate"
+mode where invoking the action repeatedly will toggle between normal
+formatting and alternate formatting each time you invoke it. For
+a short comment that means toggling between a multi-line and a
+single-line comment. But for a longer comment, it will toggle between
+optimal line breaking (the default) and greedy line breaking, which
+can look better for short paragraphs.
 
 You can also configure whether the formatter should do more than
-formatting and actually replace markup constructs like <b>bold</b>
-with markdown markup.
+formatting and actually replace markup constructs like **bold** with
+markdown markup.
 
 ![Screenshot](screenshot-settings.png)
-
 
 The plugin is available from the JetBrains Marketplace at
 [https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter](https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter)
@@ -161,64 +152,75 @@ kdocformatter {
     options = "--single-line-comments=collapse --max-line-width=100"
 }
 ```
-Here, the [options] property lets you use any of the command line flags
-from the kdoc-formatter command.
+
+Here, the [options] property lets you use any of the command line
+flags from the kdoc-formatter command.
 
 Building and testing
 --------------------
 To create an installation of the command line tool, run
+
 ```
 ./gradlew install
 ```
+
 The installation will be located in cli/build/install/kdocformatter.
 
 To create a zip, run
+
 ```
 ./gradlew zip
 ```
+
 To build the plugin, run
+
 ```
 ./gradlew :plugin:buildPlugin
 ```
+
 The plugin will be located in plugin/build/distributions/.
 
 To run/test the plugin in the IDE, run
+
 ```
 ./gradlew runIde
 ```
 
 To reformat the source tree run
+
 ```
 ./gradlew format
 ```
 
 To build the Gradle plugin locally:
+
 ```
 cd gradle-plugin
 ./gradlew publish
 ```
+
 This will create a Maven local repository in m2/ which you can then
 point to from your consuming projects as shown in the Gradle Plugin
 Usage section above.
 
 Support Javadoc?
 ----------------
-KDoc is pretty similar to javadoc and there's a good chance that most
-of this functionality would work well. However, I already use
+KDoc is pretty similar to javadoc and there's a good chance that
+most of this functionality would work well. However, I already use
 [google-java-formatter](https://github.com/google/google-java-format)
 to format all Java source code, which does a great job reflowing
-javadoc comments already (along with formatting the rest of the file),
-so makign this tool support Java is not needed.
+javadoc comments already (along with formatting the rest of
+the file), so making this tool support Java is not needed.
 
 Integrate into ktlint?
 ----------------------
 I use [ktlint](https://github.com/pinterest/ktlint) to format and
-pretty-print my Kotlin source code.  However, it does not do comment
+pretty-print my Kotlin source code. However, it does not do comment
 reformatting, which means I spend time either manually reflowing
 myself when I edit comments, or worse, leave it unformatted.
 
-Given that I use ktlint for formatting, the Right Thing would have
-been for me to figure out how it works, and implement the
+Given that I use ktlint for formatting, the Right Thing would
+have been for me to figure out how it works, and implement the
 functionality there. However, I'm busy with a million other things,
 and this was just a quick weekend -- which unfortunately satisfies my
 immediate formatting needs -- so I no longer have the same motivation

--- a/cli/src/main/kotlin/kdocformatter/cli/GitRangeFilter.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/GitRangeFilter.kt
@@ -10,8 +10,8 @@ import java.nio.file.Files
  * these.
  *
  * TODO: Allow specifying an arbitrary range of git sha's. This requires
- * some work to figure out the correct line numbers in the current
- * version from older patches.
+ *     some work to figure out the correct line numbers
+ *     in the current version from older patches.
  */
 class GitRangeFilter private constructor(rangeMap: RangeMap) : LineRangeFilter(rangeMap) {
     companion object {

--- a/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormatter.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormatter.kt
@@ -30,7 +30,9 @@ class KDocFileFormatter(private val options: KDocFileFormattingOptions) {
             return count
         }
 
-        return if (file.path.endsWith(".kt") && options.filter.includes(file)) {
+        return if (file.path.endsWith(".kt") && options.filter.includes(file) ||
+            options.includeMd && file.path.endsWith(".md") && options.filter.includes(file)
+        ) {
             val original = file.readText()
             val reformatted = reformatFile(file, original)
             if (reformatted != original) {
@@ -49,6 +51,12 @@ class KDocFileFormatter(private val options: KDocFileFormattingOptions) {
     }
 
     fun reformatFile(file: File?, source: String): String {
+        if (file != null && file.path.endsWith(".md")) {
+            val formattingOptions = file.let { EditorConfigs.getOptions(it) }
+            val formatter = KDocFormatter(formattingOptions)
+            return formatter.reformatMarkdown(source)
+        }
+
         val sb = StringBuilder()
         val tokens = tokenizeKotlin(source)
         val formattingOptions = file?.let { EditorConfigs.getOptions(it) } ?: options.formattingOptions

--- a/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormattingOptions.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormattingOptions.kt
@@ -19,6 +19,7 @@ class KDocFileFormattingOptions {
     var formattingOptions: KDocFormattingOptions = KDocFormattingOptions()
     var gitStaged = false
     var gitHead = false
+    var includeMd: Boolean = false
 
     companion object {
         fun parse(args: Array<String>): KDocFileFormattingOptions {
@@ -47,6 +48,7 @@ class KDocFileFormattingOptions {
                     arg.startsWith("--hanging-indent=") ->
                         options.formattingOptions.hangingIndent = parseInt(arg.substring("--hanging-indent=".length))
                     arg == "--convert-markup" -> options.formattingOptions.convertMarkup = true
+                    arg == "--add-punctuation" -> options.formattingOptions.addPunctuation = true
                     arg.startsWith("--single-line-comments=collapse") ->
                         options.formattingOptions.collapseSingleLine = true
                     arg.startsWith("--single-line-comments=expand") ->
@@ -63,6 +65,8 @@ class KDocFileFormattingOptions {
                     arg == "--quiet" || arg == "-q" -> options.quiet = true
                     arg == "--git-path" -> options.gitPath = args[i++]
                     arg.startsWith("--git-path=") -> options.gitPath = arg.substring("--git-path=".length)
+                    arg == "--include-md-files" -> options.includeMd = true
+                    arg == "--greedy" -> options.formattingOptions.optimal = false
                     else -> {
                         val paths =
                             if (arg.startsWith("@")) {
@@ -137,6 +141,9 @@ class KDocFileFormattingOptions {
                 and subsequent lines in a bulleted list or kdoc blog tag.
               --convert-markup
                 Convert unnecessary HTML tags like &lt; and &gt; into < and >
+              --add-punctuation
+                Add missing punctuation, such as a period at the end of a capitalized
+                paragraph.
               --single-line-comments=<collapse | expand>
                 With `collapse`, turns multi-line comments into a single line if it
                 fits, and with `expand` it will always format commands with /** and
@@ -149,6 +156,11 @@ class KDocFileFormattingOptions {
               --lines <start:end>, --line <start>
                 Line range(s) to format, like 5:10 (1-based; default is all). Can be
                 specified multiple times.
+              --include-md-files
+                Format markdown (*.md) files
+              --greedy
+                Instead of the optimal line breaking normally used by kdoc-formatter,
+                do greedy line breaking instead
               --dry-run, -n
                 Prints the paths of the files whose contents would change if the
                 formatter were run normally.

--- a/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
+++ b/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
@@ -1,5 +1,6 @@
 package kdocformatter.cli
 
+import kdocformatter.KDocFormatter
 import kdocformatter.KDocFormattingOptions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -93,8 +94,8 @@ class KDocFileFormatterTest {
             //3456789012345678901234567890 <- 30
             /**
              * This should fit on a single
-             * And this should also fit!! 
-             * And this should not!!!!!!!!! 
+             * And this should also fit!!
+             * And this should not!!!!!!!!!
              */
             """.trimIndent()
         val reformatted = reformatFile(source, KDocFormattingOptions(30))
@@ -128,7 +129,7 @@ class KDocFileFormatterTest {
              * *bold* should not be removed even at beginning.
                  */
                 private var checkAllWarnings: Boolean? = null
-            
+
                 /** Returns whether lint should check all warnings,
                  * including those off by default */  // additional
                 private var ignoreAll: Boolean? = null
@@ -149,7 +150,7 @@ class KDocFileFormatterTest {
             +++ Test.kt
             @@ -15 +15 @@ class Test {
             -     * including those off by default */  // additional
-            +     * modified including those off by default */  // additional            
+            +     * modified including those off by default */  // additional
             diff --git a/README.md b/README.md
             index c26815b..30a8dbb 100644
             --- README.md
@@ -180,13 +181,476 @@ class KDocFileFormatterTest {
              * *bold* should not be removed even at beginning.
                  */
                 private var checkAllWarnings: Boolean? = null
-            
+
                 /**
                  * Returns whether lint should check all warnings, including those
                  * off by default
                  */  // additional
                 private var ignoreAll: Boolean? = null
             }
+            """.trimIndent(),
+            reformatted
+        )
+    }
+
+    @Test
+    fun testFormatMd() {
+        val source =
+            """
+            KDoc Formatter
+            ==============
+
+            Reformats Kotlin KDoc comments, reflowing text and other cleanup, both
+            via IDE plugin and command line utility.
+
+            This tool reflows comments in KDoc; either on a file or recursively
+            over nested folders, as well as an IntelliJ IDE plugin where you can
+            reflow the current comment around the cursor.
+
+            Features
+            --------
+
+            * Reflow using optimal instead of greedy algorithm (though in the IDE
+              plugin you can turn on alternate formatting and invoking the action
+              repeatedly alternates between the two modes.)
+
+            * Command line script which can recursively format a whole source
+              folder.
+
+            * IDE plugin to format selected files or current comment. Preserves
+              caret position in the current comment.
+
+            * Gradle plugin to format the source folders in the current project.
+
+            * Block tags (like @param) are separated out from the main text, and
+              subsequent lines are indented. Blank spaces between doc tags
+              are removed. Preformatted text (indented 4 spaces or more) is left
+              alone.
+
+            * Can be run in a mode where it only reformats comments that were
+              touched by the current git HEAD commit, or the currently staged
+              files. Can also be passed specific line ranges to limit formatting
+              to.
+
+            * Multiline comments that would fit on a single line are converted to
+              a single line comment (configurable via options)
+
+            * Adds hanging indents for ordered and unordered indents.
+
+            * Cleans up the double spaces left by the IntelliJ "Convert to Kotlin"
+              action right before the closing comment token.
+
+            * Removes trailing spaces.
+
+            * Can optionally convert various remaining HTML tags in the comments
+              to the corresponding KDoc/markdown text. For example, <b>bold</b> is
+              converted into **bold**, <p> is converted to a blank line,
+              <h1>Heading</h1> is converted into # Heading, and so on.
+
+            * Support for .editorconfig configuration files to automatically pick
+              up line widths. It will normally use the line width configured for
+              Kotlin files, but, if Markdown (.md) files are also configured, it
+              will use that width as the maximum comment width. This allows you to
+              have code line widths of for example 140 but limit comments to 70
+              characters (possibly indented). For code, avoiding line breaking is
+              helpful, but for text, shorter lines are better for reading.
+
+            Command Usage
+            -------------
+            ```
+            ${'$'} kdoc-formatter
+            Usage: kdoc-formatter [options] file(s)
+
+            Options:
+              --max-line-width=<n>
+                Sets the length of lines. Defaults to 72.
+              --max-comment-width=<n>
+                Sets the maximum width of comments. This is helpful in a codebase
+                with large line lengths, such as 140 in the IntelliJ codebase. Here,
+                you don't want to limit the formatter maximum line width since
+                indented code still needs to be properly formatted, but you also
+                don't want comments to span 100+ characters, since that's less
+                readable. By default this option is not set.
+              --hanging-indent=<n>
+                Sets the number of spaces to use for hanging indents, e.g. second
+                and subsequent lines in a bulleted list or kdoc blog tag.
+              --convert-markup
+                Convert unnecessary HTML tags like &lt; and &gt; into < and >
+              --single-line-comments=<collapse | expand>
+                With `collapse`, turns multi-line comments into a single line if it
+                fits, and with `expand` it will always format commands with /** and
+                */ on their own lines. The default is `collapse`.
+              --overlaps-git-changes=<HEAD | staged>
+                If git is on the path, and the command is invoked in a git
+                repository, kdoc-formatter will invoke git to find the changes either
+                in the HEAD commit or in the staged files, and will format only the
+                KDoc comments that overlap these changes.
+              --lines <start:end>, --line <start>
+                Line range(s) to format, like 5:10 (1-based; default is all). Can be
+                specified multiple times.
+              --dry-run, -n
+                Prints the paths of the files whose contents would change if the
+                formatter were run normally.
+              --quiet, -q
+                Quiet mode
+              --help, -help, -h
+                Print this usage statement.
+              @<filename>
+                Read filenames from file.
+
+            kdoc-formatter: Version 1.3
+            https://github.com/tnorbye/kdoc-formatter
+            ```
+
+            IntelliJ Plugin Usage
+            ---------------------
+            Install the IDE plugin. Then move the caret to a KDoc comment and invoke
+            Code > Reformat KDoc. You can configure a keyboard shortcut if you perform
+            this action frequently (go to Preferences, search for Keymap, and then
+            in the Keymap search field look for "KDoc", and then double click and
+            choose Add Keyboard Shortcut.
+
+            You can also select one or more files in the
+            Project View and invoke the same action to format whole files.
+
+            ![Screenshot](screenshot.png)
+
+            Finally, you can configure various options in the Settings panel.
+            The line length settings are inherited from the IDE code style or
+            from the .editorconfig files, if any. However, you can turn on
+            "alternate" mode where invoking the action repeatedly will toggle
+            between normal formatting and alternate formatting each time you
+            invoke it. For a short comment that means toggling between a
+            multi-line and a single-line comment. But for a longer comment,
+            it will toggle between optimal line breaking (the default) and
+            greedy line breaking, which can look better for short paragraphs.
+
+            You can also configure whether the formatter should do more than
+            formatting and actually replace markup constructs like <b>bold</b>
+            with markdown markup.
+
+            ![Screenshot](screenshot-settings.png)
+
+
+            The plugin is available from the JetBrains Marketplace at
+            [https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter](https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter)
+
+            Gradle Plugin Usage
+            -------------------
+            The plugin is not yet distributed, so for now, download the zip file
+            and install it somewhere, then add this to your build.gradle file:
+
+            ```
+            buildscript {
+                repositories {
+                    maven { url '/path/to/m2' }
+                }
+                dependencies {
+                    classpath "com.github.tnorbye.kdoc-formatter:kdocformatter:1.1.1"
+                    // (Sorry about the vanity URL --
+                    // I tried to get kdoc-formatter:kdoc-formatter:1.1.1 but that
+                    // didn't meet the naming requirements for publishing:
+                    // https://issues.sonatype.org/browse/OSSRH-63191)
+                }
+            }
+            plugins {
+                id 'kdoc-formatter'
+            }
+            kdocformatter {
+                options = "--single-line-comments=collapse --max-line-width=100"
+            }
+            ```
+            Here, the [options] property lets you use any of the command line flags
+            from the kdoc-formatter command.
+
+            Building and testing
+            --------------------
+            To create an installation of the command line tool, run
+            ```
+            ./gradlew install
+            ```
+            The installation will be located in cli/build/install/kdocformatter.
+
+            To create a zip, run
+            ```
+            ./gradlew zip
+            ```
+            To build the plugin, run
+            ```
+            ./gradlew :plugin:buildPlugin
+            ```
+            The plugin will be located in plugin/build/distributions/.
+
+            To run/test the plugin in the IDE, run
+            ```
+            ./gradlew runIde
+            ```
+
+            To reformat the source tree run
+            ```
+            ./gradlew format
+            ```
+
+            To build the Gradle plugin locally:
+            ```
+            cd gradle-plugin
+            ./gradlew publish
+            ```
+            This will create a Maven local repository in m2/ which you can then
+            point to from your consuming projects as shown in the Gradle Plugin
+            Usage section above.
+
+            Support Javadoc?
+            ----------------
+            KDoc is pretty similar to javadoc and there's a good chance that most
+            of this functionality would work well. However, I already use
+            [google-java-formatter](https://github.com/google/google-java-format)
+            to format all Java source code, which does a great job reflowing
+            javadoc comments already (along with formatting the rest of the file),
+            so makign this tool support Java is not needed.
+
+            Integrate into ktlint?
+            ----------------------
+            I use [ktlint](https://github.com/pinterest/ktlint) to format and
+            pretty-print my Kotlin source code.  However, it does not do comment
+            reformatting, which means I spend time either manually reflowing
+            myself when I edit comments, or worse, leave it unformatted.
+
+            Given that I use ktlint for formatting, the Right Thing would have
+            been for me to figure out how it works, and implement the
+            functionality there. However, I'm busy with a million other things,
+            and this was just a quick weekend -- which unfortunately satisfies my
+            immediate formatting needs -- so I no longer have the same motivation
+            to get ktlint to support it.
+            """.trimIndent()
+
+        val fileOptions = KDocFileFormattingOptions()
+        val options = KDocFormattingOptions(72)
+        options.optimal = false
+        fileOptions.formattingOptions = options
+        val formatter = KDocFormatter(fileOptions.formattingOptions)
+        val reformatted = formatter.reformatMarkdown(source)
+        assertEquals(
+            """
+            KDoc Formatter
+            ==============
+
+            Reformats Kotlin KDoc comments, reflowing text and other cleanup,
+            both via IDE plugin and command line utility.
+
+            This tool reflows comments in KDoc; either on a file or recursively
+            over nested folders, as well as an IntelliJ IDE plugin where you can
+            reflow the current comment around the cursor.
+
+            Features
+            --------
+            * Reflow using optimal instead of greedy algorithm (though in the IDE
+              plugin you can turn on alternate formatting and invoking the action
+              repeatedly alternates between the two modes.)
+            * Command line script which can recursively format a whole source
+              folder.
+            * IDE plugin to format selected files or current comment. Preserves
+              caret position in the current comment.
+            * Gradle plugin to format the source folders in the current project.
+            * Block tags (like @param) are separated out from the main text, and
+              subsequent lines are indented. Blank spaces between doc tags are removed.
+              Preformatted text (indented 4 spaces or more) is left alone.
+            * Can be run in a mode where it only reformats comments that were
+              touched by the current git HEAD commit, or the currently staged files. Can
+              also be passed specific line ranges to limit formatting to.
+            * Multiline comments that would fit on a single line are converted to
+              a single line comment (configurable via options)
+            * Adds hanging indents for ordered and unordered indents.
+            * Cleans up the double spaces left by the IntelliJ "Convert to
+              Kotlin" action right before the closing comment token.
+            * Removes trailing spaces.
+            * Can optionally convert various remaining HTML tags in the comments
+              to the corresponding KDoc/markdown text. For example, **bold** is
+              converted into **bold**, <p> is converted to a blank line, <h1>Heading</h1>
+              is converted into # Heading, and so on.
+            * Support for .editorconfig configuration files to automatically pick
+              up line widths. It will normally use the line width configured for
+              Kotlin files, but, if Markdown (.md) files are also configured, it will
+              use that width as the maximum comment width. This allows you to have
+              code line widths of for example 140 but limit comments to 70 characters
+              (possibly indented). For code, avoiding line breaking is helpful, but for
+              text, shorter lines are better for reading.
+
+            Command Usage
+            -------------
+
+            ```
+            ${'$'} kdoc-formatter
+            Usage: kdoc-formatter [options] file(s)
+
+            Options:
+              --max-line-width=<n>
+                Sets the length of lines. Defaults to 72.
+              --max-comment-width=<n>
+                Sets the maximum width of comments. This is helpful in a codebase
+                with large line lengths, such as 140 in the IntelliJ codebase. Here,
+                you don't want to limit the formatter maximum line width since
+                indented code still needs to be properly formatted, but you also
+                don't want comments to span 100+ characters, since that's less
+                readable. By default this option is not set.
+              --hanging-indent=<n>
+                Sets the number of spaces to use for hanging indents, e.g. second
+                and subsequent lines in a bulleted list or kdoc blog tag.
+              --convert-markup
+                Convert unnecessary HTML tags like &lt; and &gt; into < and >
+              --single-line-comments=<collapse | expand>
+                With `collapse`, turns multi-line comments into a single line if it
+                fits, and with `expand` it will always format commands with /** and
+                */ on their own lines. The default is `collapse`.
+              --overlaps-git-changes=<HEAD | staged>
+                If git is on the path, and the command is invoked in a git
+                repository, kdoc-formatter will invoke git to find the changes either
+                in the HEAD commit or in the staged files, and will format only the
+                KDoc comments that overlap these changes.
+              --lines <start:end>, --line <start>
+                Line range(s) to format, like 5:10 (1-based; default is all). Can be
+                specified multiple times.
+              --dry-run, -n
+                Prints the paths of the files whose contents would change if the
+                formatter were run normally.
+              --quiet, -q
+                Quiet mode
+              --help, -help, -h
+                Print this usage statement.
+              @<filename>
+                Read filenames from file.
+
+            kdoc-formatter: Version 1.3
+            https://github.com/tnorbye/kdoc-formatter
+            ```
+
+            IntelliJ Plugin Usage
+            ---------------------
+            Install the IDE plugin. Then move the caret to a KDoc comment and
+            invoke Code > Reformat KDoc. You can configure a keyboard shortcut if you
+            perform this action frequently (go to Preferences, search for Keymap, and
+            then in the Keymap search field look for "KDoc", and then double click
+            and choose Add Keyboard Shortcut.
+
+            You can also select one or more files in the Project View and invoke
+            the same action to format whole files.
+
+            ![Screenshot](screenshot.png)
+
+            Finally, you can configure various options in the Settings panel. The
+            line length settings are inherited from the IDE code style or from the
+            .editorconfig files, if any. However, you can turn on "alternate" mode where
+            invoking the action repeatedly will toggle between normal formatting and
+            alternate formatting each time you invoke it. For a short comment that means
+            toggling between a multi-line and a single-line comment. But for a longer
+            comment, it will toggle between optimal line breaking (the default) and
+            greedy line breaking, which can look better for short paragraphs.
+
+            You can also configure whether the formatter should do more than
+            formatting and actually replace markup constructs like **bold** with markdown
+            markup.
+
+            ![Screenshot](screenshot-settings.png)
+
+            The plugin is available from the JetBrains Marketplace at
+            [https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter](https://plugins.jetbrains.com/plugin/15734-kotlin-kdoc-formatter)
+
+            Gradle Plugin Usage
+            -------------------
+            The plugin is not yet distributed, so for now, download the zip file
+            and install it somewhere, then add this to your build.gradle file:
+
+            ```
+            buildscript {
+                repositories {
+                    maven { url '/path/to/m2' }
+                }
+                dependencies {
+                    classpath "com.github.tnorbye.kdoc-formatter:kdocformatter:1.1.1"
+                    // (Sorry about the vanity URL --
+                    // I tried to get kdoc-formatter:kdoc-formatter:1.1.1 but that
+                    // didn't meet the naming requirements for publishing:
+                    // https://issues.sonatype.org/browse/OSSRH-63191)
+                }
+            }
+            plugins {
+                id 'kdoc-formatter'
+            }
+            kdocformatter {
+                options = "--single-line-comments=collapse --max-line-width=100"
+            }
+            ```
+
+            Here, the [options] property lets you use any of the command line
+            flags from the kdoc-formatter command.
+
+            Building and testing
+            --------------------
+            To create an installation of the command line tool, run
+
+            ```
+            ./gradlew install
+            ```
+
+            The installation will be located in cli/build/install/kdocformatter.
+
+            To create a zip, run
+
+            ```
+            ./gradlew zip
+            ```
+
+            To build the plugin, run
+
+            ```
+            ./gradlew :plugin:buildPlugin
+            ```
+
+            The plugin will be located in plugin/build/distributions/.
+
+            To run/test the plugin in the IDE, run
+
+            ```
+            ./gradlew runIde
+            ```
+
+            To reformat the source tree run
+
+            ```
+            ./gradlew format
+            ```
+
+            To build the Gradle plugin locally:
+
+            ```
+            cd gradle-plugin
+            ./gradlew publish
+            ```
+
+            This will create a Maven local repository in m2/ which you can then
+            point to from your consuming projects as shown in the Gradle Plugin Usage
+            section above.
+
+            Support Javadoc?
+            ----------------
+            KDoc is pretty similar to javadoc and there's a good chance that most
+            of this functionality would work well. However, I already use
+            [google-java-formatter](https://github.com/google/google-java-format) to format all Java source code, which does a great job reflowing
+            javadoc comments already (along with formatting the rest of the file), so
+            makign this tool support Java is not needed.
+
+            Integrate into ktlint?
+            ----------------------
+            I use [ktlint](https://github.com/pinterest/ktlint) to format and
+            pretty-print my Kotlin source code. However, it does not do comment reformatting,
+            which means I spend time either manually reflowing myself when I edit
+            comments, or worse, leave it unformatted.
+
+            Given that I use ktlint for formatting, the Right Thing would have
+            been for me to figure out how it works, and implement the functionality
+            there. However, I'm busy with a million other things, and this was just a
+            quick weekend -- which unfortunately satisfies my immediate formatting
+            needs -- so I no longer have the same motivation to get ktlint to support it.
             """.trimIndent(),
             reformatted
         )

--- a/ide-plugin/build.gradle
+++ b/ide-plugin/build.gradle
@@ -34,6 +34,20 @@ intellij {
 patchPluginXml {
     changeNotes """
 <p>
+1.3.1: This version contains the following improvements:
+<ul>
+<li>Fix a few bugs around markup conversion not producing the right number
+of blank lines for a &lt;p>, as well as add a few more prefixes as
+non-breakable (e.g. if you have an em dash in your sentence -- like
+this -- we don't want the "--" to be placed at the beginning of a
+line.)
+<li>Also adds an --add-punctuation command line flag and IDE setting to
+optionally add closing periods on capitalized paragraphs at the end of
+the comment.
+<li>Special cases TODO: comments (placing them in a block by themselves
+and using hanging indents).
+</ul>
+<p>
 1.3.0: This version contains the following improvements:
 <ul>
 <li> Many improves to the markdown handling, such as quoted

--- a/ide-plugin/src/main/java/kdocformatter/plugin/KDocOptionsConfigurable.kt
+++ b/ide-plugin/src/main/java/kdocformatter/plugin/KDocOptionsConfigurable.kt
@@ -15,6 +15,7 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     private val alternateCheckBox = JBCheckBox("Alternate line breaking algorithms when invoked repeatedly")
     private val collapseLinesCheckBox = JBCheckBox("Collapse short comments that fit on a single line")
     private val convertMarkupCheckBox = JBCheckBox("Convert markup like <b>bold</b> into **bold**")
+    private val addPunctuationCheckBox = JBCheckBox("Add missing punctuation")
     private val lineCommentsCheckBox = JBCheckBox("Allow formatting line comments interactively")
 
     private val state = KDocPluginOptions.instance.globalState
@@ -23,6 +24,7 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
         row { alternateCheckBox() }
         row { collapseLinesCheckBox() }
         row { convertMarkupCheckBox() }
+        row { addPunctuationCheckBox() }
         row { lineCommentsCheckBox() }
     }
 
@@ -30,7 +32,8 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
         alternateCheckBox.isSelected != state.alternateActions ||
             collapseLinesCheckBox.isSelected != state.collapseSingleLines ||
             convertMarkupCheckBox.isSelected != state.convertMarkup ||
-            lineCommentsCheckBox.isSelected != state.lineComments
+            lineCommentsCheckBox.isSelected != state.lineComments ||
+            addPunctuationCheckBox.isSelected != state.addPunctuation
 
     @Throws(ConfigurationException::class)
     override fun apply() {
@@ -38,6 +41,7 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
         state.collapseSingleLines = collapseLinesCheckBox.isSelected
         state.convertMarkup = convertMarkupCheckBox.isSelected
         state.lineComments = lineCommentsCheckBox.isSelected
+        state.addPunctuation = addPunctuationCheckBox.isSelected
     }
 
     override fun reset() {
@@ -45,5 +49,6 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
         collapseLinesCheckBox.isSelected = state.collapseSingleLines
         convertMarkupCheckBox.isSelected = state.convertMarkup
         lineCommentsCheckBox.isSelected = state.lineComments
+        addPunctuationCheckBox.isSelected = state.addPunctuation
     }
 }

--- a/ide-plugin/src/main/java/kdocformatter/plugin/KDocPluginOptions.kt
+++ b/ide-plugin/src/main/java/kdocformatter/plugin/KDocPluginOptions.kt
@@ -44,6 +44,7 @@ class KDocPluginOptions : PersistentStateComponent<KDocPluginOptions.ComponentSt
         var collapseSingleLines = true
         var convertMarkup = false
         var lineComments = false
+        var addPunctuation = false
     }
 
     companion object {

--- a/ide-plugin/src/main/java/kdocformatter/plugin/ReformatKDocAction.kt
+++ b/ide-plugin/src/main/java/kdocformatter/plugin/ReformatKDocAction.kt
@@ -257,6 +257,7 @@ class ReformatKDocAction : AnAction() {
         }
         configOptions.convertMarkup = state.convertMarkup
         configOptions.alternate = alternate
+        configOptions.addPunctuation = state.addPunctuation
         return configOptions
     }
 

--- a/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
@@ -54,9 +54,8 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
 
             val maxLineWidth = min(
                 options.maxCommentWidth,
-                options.maxLineWidth - indentSize - 3 -
-                    if (paragraph.quoted) 2 else 0
-            )
+                options.maxLineWidth - indentSize - 3
+            ) - if (paragraph.quoted) 2 else 0
 
             val lines = paragraph.reflow(maxLineWidth, options)
             var first = true
@@ -102,5 +101,25 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
         } else if (lineComment && sb.endsWith("// ")) {
             sb.setLength(sb.length - 1)
         }
+    }
+
+    /** Reformats a markdown document */
+    fun reformatMarkdown(md: String): String {
+        // Just leverage the comment machinery here -- convert the markdown into a
+        // kdoc comment, reformat that, and then uncomment it
+        val comment = "/**\n" + md.split("\n").joinToString(separator = "\n") { " * $it" } + "\n*/"
+        val reformattedComment = " " + reformatComment(comment, "")
+            .trim().removePrefix("/**").removeSuffix("*/").trim()
+        val reformatted = reformattedComment.split("\n").joinToString(separator = "\n") {
+            if (it.startsWith(" * "))
+                it.substring(3)
+            else if (it.startsWith(" *"))
+                ""
+            else if (it.startsWith("* "))
+                it.substring(2)
+            else
+                it
+        }
+        return reformatted
     }
 }

--- a/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
@@ -29,6 +29,14 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
     var convertMarkup: Boolean = true
 
     /**
+     * Whether to add punctuation where missing, such as ending
+     * sentences with a period. (TODO: Make sure the FIRST sentence
+     * ends with one too! Especially if the subsequent sentence is
+     * separated.)
+     */
+    var addPunctuation: Boolean = false
+
+    /**
      * How many spaces to use for hanging indents in numbered lists and
      * after block tags
      */
@@ -41,6 +49,9 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
      * But if you do, this is the tab width.
      */
     var tabWidth: Int = 8
+
+    /** Whether to perform optimal line breaking instead of greeding */
+    var optimal: Boolean = true
 
     /**
      * If true, perform "alternative" formatting. This is only relevant

--- a/library/src/main/kotlin/kdocformatter/Utilities.kt
+++ b/library/src/main/kotlin/kdocformatter/Utilities.kt
@@ -60,6 +60,10 @@ fun String.collapseSpaces(): String {
     return sb.trimEnd().toString()
 }
 
+fun String.isTodo(): Boolean {
+    return startsWith("TODO:")
+}
+
 fun String.isKDocTag(): Boolean {
     if (!startsWith("@")) {
         return false

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.3
+buildVersion = 1.3.1


### PR DESCRIPTION
This version
* Adds --add-punctuation flag (and IDE option) to add missing
  punctuation.
* Improves handling of TODO: items.
* Fixes a few markup conversion and word breaking bugs.