### PR TITLE
Enable punctuation at the end of paragraphs ending with a [LabelLink]

### DIFF
--- a/library/src/main/kotlin/kdocformatter/ParagraphListBuilder.kt
+++ b/library/src/main/kotlin/kdocformatter/ParagraphListBuilder.kt
@@ -382,13 +382,18 @@ class ParagraphListBuilder(
         if (last.preformatted || last.doc || last.hanging && !last.continuation || last.isEmpty()) {
             return
         }
+
         val text = last.content
+        if (!text.startsWithUpperCaseLetter()) {
+            return
+        }
+
         for (i in text.length - 1 downTo 0) {
             val c = text[i]
             if (c.isWhitespace()) {
                 continue
             }
-            if ((c.isLetterOrDigit() || c.isCloseSquareBracket()) && text[0].isUpperCaseLetter()) {
+            if (c.isLetterOrDigit() || c.isCloseSquareBracket()) {
                 text.setLength(i + 1)
                 text.append('.')
             }
@@ -406,6 +411,7 @@ fun String.containsOnly(vararg s: Char): Boolean {
     return true
 }
 
-fun Char.isUpperCaseLetter() = isLetter() && isUpperCase()
+fun StringBuilder.startsWithUpperCaseLetter() =
+    this.isNotEmpty() && this[0].isUpperCase() && this[0].isLetter()
 
 fun Char.isCloseSquareBracket() = this == ']'

--- a/library/src/main/kotlin/kdocformatter/ParagraphListBuilder.kt
+++ b/library/src/main/kotlin/kdocformatter/ParagraphListBuilder.kt
@@ -388,7 +388,7 @@ class ParagraphListBuilder(
             if (c.isWhitespace()) {
                 continue
             }
-            if (c.isLetterOrDigit() && text[0].isLetter() && text[0].isUpperCase()) {
+            if ((c.isLetterOrDigit() || c.isCloseSquareBracket()) && text[0].isUpperCaseLetter()) {
                 text.setLength(i + 1)
                 text.append('.')
             }
@@ -405,3 +405,7 @@ fun String.containsOnly(vararg s: Char): Boolean {
     }
     return true
 }
+
+fun Char.isUpperCaseLetter() = isLetter() && isUpperCase()
+
+fun Char.isCloseSquareBracket() = this == ']'

--- a/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
@@ -386,6 +386,23 @@ class KDocFormatterTest {
     }
 
     @Test
+    fun testPunctuationWithLabelLink() {
+        val source =
+            """
+             /** Default implementation of [MyInterface] */
+            """.trimIndent()
+
+        val options = KDocFormattingOptions(72)
+        options.addPunctuation = true
+        checkFormatter(
+            source, options,
+            """
+             /** Default implementation of [MyInterface]. */
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun testPreformattedText() {
         val source =
             """


### PR DESCRIPTION
More details in https://github.com/tnorbye/kdoc-formatter/issues/29. 

Closes https://github.com/tnorbye/kdoc-formatter/issues/29.