### PR TITLE
Avoid line wrapping for text inside square brackets.

### DIFF
--- a/library/src/main/kotlin/kdocformatter/Paragraph.kt
+++ b/library/src/main/kotlin/kdocformatter/Paragraph.kt
@@ -163,14 +163,20 @@ class Paragraph(private val options: KDocFormattingOptions) {
         val combined = ArrayList<String>(words.size)
         combined.add(words[0])
         var prev = ""
+        var insideSquareBrackets = false
         for (i in 1 until words.size) {
             val word = words[i]
+
+            if(prev.startsWith("[")) insideSquareBrackets = true
+            if(prev.contains("]")) insideSquareBrackets = false
+
             // Can we start a new line with this without interpreting it
             // in a special way?
             if (word.startsWith("#") ||
                 word.startsWith("-") ||
                 word == "```" ||
-                word.isListItem() && !word.equals("<li>", true)
+                word.isListItem() && !word.equals("<li>", true) ||
+                insideSquareBrackets
             ) {
                 // Combine with previous word with a single space; the line breaking algorithm
                 // won't know that it's more than one word.

--- a/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
@@ -403,6 +403,29 @@ class KDocFormatterTest {
     }
 
     @Test
+    fun testWrapingOfLinkText() {
+        val source =
+            """
+             /**
+              * Sometimes the text of a link can have spaces, like [this link's text](https://example.com).
+              * The following text should wrap like usual.
+              */
+            """.trimIndent()
+
+        val options = KDocFormattingOptions(72)
+        checkFormatter(
+            source, options,
+            """
+            /**
+             * Sometimes the text of a link can have spaces, like
+             * [this link's text](https://example.com). The following text should
+             * wrap like usual.
+             */
+             """.trimIndent()
+        )
+    }
+
+    @Test
     fun testPreformattedText() {
         val source =
             """

--- a/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
@@ -418,8 +418,8 @@ class KDocFormatterTest {
             """
             /**
              * Sometimes the text of a link can have spaces, like
-             * [this link's text](https://example.com). The following text should
-             * wrap like usual.
+             * [this link's text](https://example.com). The following text
+             * should wrap like usual.
              */
              """.trimIndent()
         )


### PR DESCRIPTION
While usind the IntelliJ plugin I found that the text of a link is also wrapped wich led to a star being included in the link's text. I figured that this might not be a desired result so I did some changes to the Paragraph wrapper.

I hope this is also helpfull for other people.