### PR TITLE
1.3.3: Don't break lines in link text

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         run: ./gradlew build test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Version 1.3.3
+=============
+Bug fixes:
+* Avoid line wrapping for text inside square brackets,
+  contributed by Daniel Sturm
+
 Version 1.3.2
 =============
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Options:
   @<filename>
     Read filenames from file.
 
-kdoc-formatter: Version 1.3.2
+kdoc-formatter: Version 1.3.3
 https://github.com/tnorbye/kdoc-formatter
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     apply from: "$rootDir/version.gradle"
 
     ext {
-        gradlePluginVersion = '7.0.0-alpha04'
+        gradlePluginVersion = '7.2.0-alpha04'
     }
 
     repositories {
@@ -44,7 +44,7 @@ configurations {
 }
 
 dependencies {
-    ktlint "com.pinterest:ktlint:0.40.0"
+    ktlint "com.pinterest:ktlint:0.43.0"
 }
 
 task format(type: JavaExec, group: "verification") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 05 15:49:25 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/ide-plugin/build.gradle
+++ b/ide-plugin/build.gradle
@@ -34,6 +34,10 @@ intellij {
 patchPluginXml {
     changeNotes """
 <p>
+1.3.3: Don't break lines inside link text which will
+include the comment asterisk, and allow formatting during
+indexing
+<p>
 1.3.2: Bugfixes and update deprecated API usage for 2021.2
 compatibility
 <p>

--- a/ide-plugin/src/main/java/kdocformatter/plugin/ReformatKDocAction.kt
+++ b/ide-plugin/src/main/java/kdocformatter/plugin/ReformatKDocAction.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.vfs.ReadonlyStatusHandler
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
@@ -27,7 +28,7 @@ import kdocformatter.KDocFormattingOptions
 import kdocformatter.findSamePosition
 import org.jetbrains.annotations.Nullable
 
-class ReformatKDocAction : AnAction() {
+class ReformatKDocAction : AnAction(), DumbAware {
     override fun actionPerformed(event: AnActionEvent) {
         val dataContext = event.dataContext
         val project = CommonDataKeys.PROJECT.getData(dataContext) ?: return

--- a/library/src/main/kotlin/kdocformatter/Paragraph.kt
+++ b/library/src/main/kotlin/kdocformatter/Paragraph.kt
@@ -167,8 +167,8 @@ class Paragraph(private val options: KDocFormattingOptions) {
         for (i in 1 until words.size) {
             val word = words[i]
 
-            if(prev.startsWith("[")) insideSquareBrackets = true
-            if(prev.contains("]")) insideSquareBrackets = false
+            if (prev.startsWith("[")) insideSquareBrackets = true
+            if (prev.contains("]")) insideSquareBrackets = false
 
             // Can we start a new line with this without interpreting it
             // in a special way?

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.3.2
+buildVersion = 1.3.3

--- a/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/kdocformatter/KDocFormatterTest.kt
@@ -421,7 +421,7 @@ class KDocFormatterTest {
              * [this link's text](https://example.com). The following text
              * should wrap like usual.
              */
-             """.trimIndent()
+            """.trimIndent()
         )
     }
 
@@ -1801,7 +1801,8 @@ class KDocFormatterTest {
              * which you can render with something like this:
              * `dot -Tpng -o/tmp/graph.png toString.dot`
              */
-            """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     // --------------------------------------------------------------------


### PR DESCRIPTION
Also updates some formatting and versions, and in the IDE plugin, allow formatting during indexing.