### PR TITLE
1.4.4: Misc bug fixes: greedy line breaking, <p> prefix conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 # KDoc Formatter Changelog
 
+## [1.4.4]
+- Fix bug in greedy line breaking which meant some lines were
+  actually wider than allowed by the line limit
+- Skip markup tag conversion for text inside `backticks` as
+  was already done for preformatted text
+- For lines that start with "<p>" treat these as a paragraph
+  start, as was already the case for lines containing only <p>
+  and drop these if markup conversion is enabled.
+- Don't add a blank line between text and preformatted text
+  if the preceding text ends with a colon or a comma.
+
 ## [1.4.3]
 - Support for kotlinx-knit markers
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Options:
   @<filename>
     Read filenames from file.
 
-kdoc-formatter: Version 1.4.3
+kdoc-formatter: Version 1.4.4
 https://github.com/tnorbye/kdoc-formatter
 ```
 

--- a/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
+++ b/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
@@ -114,6 +114,29 @@ class KDocFileFormatterTest {
     }
 
     @Test
+    fun testGreedyIndent() {
+        val source =
+            "" +
+                "class FormatterTest {\n" +
+                "  /**\n" +
+                "   * Handles a chain of qualified expressions, i.e. `a[5].b!!.c()[4].f()`\n" +
+                "   *\n" +
+                "   * This is by far the most complicated part of this formatter. We start by breaking the expression\n" +
+                "   * to the steps it is executed in (which are in the opposite order of how the syntax tree is\n" +
+                "   * built).\n" +
+                "   *\n" +
+                "   * We then calculate information to know which parts need to be groups, and finally go part by\n" +
+                "   * part, emitting it to the [builder] while closing and opening groups.\n" +
+                "   */\n" +
+                "  private fun emitQualifiedExpression(expression: Any) {\n" +
+                "  }\n" +
+                "}"
+        val reformatted =
+            reformatFile(source, KDocFormattingOptions(100, 100).apply { optimal = false })
+        assertEquals(source, reformatted)
+    }
+
+    @Test
     fun testGitRanges() {
         val source =
             """
@@ -453,11 +476,13 @@ class KDocFileFormatterTest {
               caret position in the current comment.
             * Gradle plugin to format the source folders in the current project.
             * Block tags (like @param) are separated out from the main text, and
-              subsequent lines are indented. Blank spaces between doc tags are removed.
-              Preformatted text (indented 4 spaces or more) is left alone.
+              subsequent lines are indented. Blank spaces between doc tags are
+              removed. Preformatted text (indented 4 spaces or more) is left
+              alone.
             * Can be run in a mode where it only reformats comments that were
-              touched by the current git HEAD commit, or the currently staged files. Can
-              also be passed specific line ranges to limit formatting to.
+              touched by the current git HEAD commit, or the currently staged
+              files. Can also be passed specific line ranges to limit formatting
+              to.
             * Multiline comments that would fit on a single line are converted to
               a single line comment (configurable via options)
             * Adds hanging indents for ordered and unordered indents.
@@ -466,15 +491,15 @@ class KDocFileFormatterTest {
             * Removes trailing spaces.
             * Can optionally convert various remaining HTML tags in the comments
               to the corresponding KDoc/markdown text. For example, **bold** is
-              converted into **bold**, <p> is converted to a blank line, <h1>Heading</h1>
-              is converted into # Heading, and so on.
+              converted into **bold**, <p> is converted to a blank line,
+              <h1>Heading</h1> is converted into # Heading, and so on.
             * Support for .editorconfig configuration files to automatically pick
               up line widths. It will normally use the line width configured for
-              Kotlin files, but, if Markdown (.md) files are also configured, it will
-              use that width as the maximum comment width. This allows you to have
-              code line widths of for example 140 but limit comments to 70 characters
-              (possibly indented). For code, avoiding line breaking is helpful, but for
-              text, shorter lines are better for reading.
+              Kotlin files, but, if Markdown (.md) files are also configured, it
+              will use that width as the maximum comment width. This allows you
+              to have code line widths of for example 140 but limit comments to
+              70 characters (possibly indented). For code, avoiding line breaking
+              is helpful, but for text, shorter lines are better for reading.
 
             Command Usage
             -------------
@@ -527,10 +552,10 @@ class KDocFileFormatterTest {
             IntelliJ Plugin Usage
             ---------------------
             Install the IDE plugin. Then move the caret to a KDoc comment and
-            invoke Code > Reformat KDoc. You can configure a keyboard shortcut if you
-            perform this action frequently (go to Preferences, search for Keymap, and
-            then in the Keymap search field look for "KDoc", and then double click
-            and choose Add Keyboard Shortcut.
+            invoke Code > Reformat KDoc. You can configure a keyboard shortcut if
+            you perform this action frequently (go to Preferences, search for
+            Keymap, and then in the Keymap search field look for "KDoc", and then
+            double click and choose Add Keyboard Shortcut.
 
             You can also select one or more files in the Project View and invoke
             the same action to format whole files.
@@ -538,17 +563,18 @@ class KDocFileFormatterTest {
             ![Screenshot](screenshot.png)
 
             Finally, you can configure various options in the Settings panel. The
-            line length settings are inherited from the IDE code style or from the
-            .editorconfig files, if any. However, you can turn on "alternate" mode where
-            invoking the action repeatedly will toggle between normal formatting and
-            alternate formatting each time you invoke it. For a short comment that means
-            toggling between a multi-line and a single-line comment. But for a longer
-            comment, it will toggle between optimal line breaking (the default) and
-            greedy line breaking, which can look better for short paragraphs.
+            line length settings are inherited from the IDE code style or from
+            the .editorconfig files, if any. However, you can turn on "alternate"
+            mode where invoking the action repeatedly will toggle between normal
+            formatting and alternate formatting each time you invoke it. For a
+            short comment that means toggling between a multi-line and a
+            single-line comment. But for a longer comment, it will toggle between
+            optimal line breaking (the default) and greedy line breaking, which
+            can look better for short paragraphs.
 
             You can also configure whether the formatter should do more than
-            formatting and actually replace markup constructs like **bold** with markdown
-            markup.
+            formatting and actually replace markup constructs like **bold** with
+            markdown markup.
 
             ![Screenshot](screenshot-settings.png)
 
@@ -559,7 +585,6 @@ class KDocFileFormatterTest {
             -------------------
             The plugin is not yet distributed, so for now, download the zip file
             and install it somewhere, then add this to your build.gradle file:
-
             ```
             buildscript {
                 repositories {
@@ -621,36 +646,37 @@ class KDocFileFormatterTest {
             ```
 
             To build the Gradle plugin locally:
-
             ```
             cd gradle-plugin
             ./gradlew publish
             ```
 
             This will create a Maven local repository in m2/ which you can then
-            point to from your consuming projects as shown in the Gradle Plugin Usage
-            section above.
+            point to from your consuming projects as shown in the Gradle Plugin
+            Usage section above.
 
             Support Javadoc?
             ----------------
             KDoc is pretty similar to javadoc and there's a good chance that most
             of this functionality would work well. However, I already use
-            [google-java-formatter](https://github.com/google/google-java-format) to format all Java source code, which does a great job reflowing
-            javadoc comments already (along with formatting the rest of the file), so
-            makign this tool support Java is not needed.
+            [google-java-formatter](https://github.com/google/google-java-format)
+            to format all Java source code, which does a great job reflowing
+            javadoc comments already (along with formatting the rest of the
+            file), so makign this tool support Java is not needed.
 
             Integrate into ktlint?
             ----------------------
             I use [ktlint](https://github.com/pinterest/ktlint) to format and
-            pretty-print my Kotlin source code. However, it does not do comment reformatting,
-            which means I spend time either manually reflowing myself when I edit
-            comments, or worse, leave it unformatted.
+            pretty-print my Kotlin source code. However, it does not do comment
+            reformatting, which means I spend time either manually reflowing
+            myself when I edit comments, or worse, leave it unformatted.
 
             Given that I use ktlint for formatting, the Right Thing would have
-            been for me to figure out how it works, and implement the functionality
-            there. However, I'm busy with a million other things, and this was just a
-            quick weekend -- which unfortunately satisfies my immediate formatting
-            needs -- so I no longer have the same motivation to get ktlint to support it.
+            been for me to figure out how it works, and implement the
+            functionality there. However, I'm busy with a million other things,
+            and this was just a quick weekend -- which unfortunately satisfies my
+            immediate formatting needs -- so I no longer have the same motivation
+            to get ktlint to support it.
             """.trimIndent(),
             reformatted
         )

--- a/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
@@ -27,6 +27,13 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
     var convertMarkup: Boolean = true
 
     /**
+     * Whether there should **always** be a newline before codeblocks.
+     * When this is not set, we'll as a special case omit the newline if
+     * the previous line ends with ":" or ",".
+     */
+    var alwaysNewLineBeforePreformatted = false
+
+    /**
      * Whether to add punctuation where missing, such as ending
      * sentences with a period. (TODO: Make sure the FIRST sentence
      * ends with one too! Especially if the subsequent sentence is
@@ -77,6 +84,7 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
         copy.collapseSpaces = collapseSpaces
         copy.hangingIndent = hangingIndent
         copy.tabWidth = tabWidth
+        copy.alwaysNewLineBeforePreformatted = alwaysNewLineBeforePreformatted
         return copy
     }
 }

--- a/library/src/main/kotlin/kdocformatter/Paragraph.kt
+++ b/library/src/main/kotlin/kdocformatter/Paragraph.kt
@@ -82,9 +82,23 @@ class Paragraph(private val options: KDocFormattingOptions) {
         val sb = StringBuilder(s.length)
         var i = 0
         val n = s.length
+        var code = false
         while (i < n) {
             val c = s[i++]
-            if (c == '<') {
+            if (c == '\\') {
+                sb.append(c)
+                if (i < n - 1) {
+                    sb.append(s[i++])
+                }
+                continue
+            } else if (c == '`') {
+                code = !code
+                sb.append(c)
+                continue
+            } else if (code) {
+                sb.append(c)
+                continue
+            } else if (c == '<') {
                 if (s.startsWith("b>", i, true) || s.startsWith("/b>", i, true)) {
                     // "<b>" or </b> -> "**"
                     sb.append('*').append('*')
@@ -398,14 +412,13 @@ class Paragraph(private val options: KDocFormattingOptions) {
                 }
                 else -> {
                     width = lineWidth
-                    if (options.hangingIndent > 0 && hanging && (lines.isNotEmpty() || continuation)
-                    ) {
+                    if (options.hangingIndent > 0 && hanging) {
                         width -= getIndentSize(hangingIndent, options)
                     }
                     lines.add(sb.toString())
-                    column = 0
                     sb.setLength(0)
                     sb.append(word)
+                    column = sb.length
                 }
             }
         }

--- a/library/src/main/kotlin/kdocformatter/Utilities.kt
+++ b/library/src/main/kotlin/kdocformatter/Utilities.kt
@@ -71,6 +71,15 @@ fun String.isDirectiveMarker(): Boolean {
     return startsWith("<!---") || startsWith("-->")
 }
 
+/**
+ * Returns true if the string ends with a symbol that implies more text
+ * is coming, e.g. ":" or ","
+ */
+fun String.isExpectingMore(): Boolean {
+    val last = lastOrNull() { !it.isWhitespace() } ?: return false
+    return last == ':' || last == ','
+}
+
 fun String.isKDocTag(): Boolean {
     if (!startsWith("@")) {
         return false

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.4.3
+buildVersion = 1.4.4


### PR DESCRIPTION
- Fix bug in greedy line breaking which meant some lines were
  actually wider than allowed by the line limit
- Skip markup tag conversion for text inside `backticks` as
  was already done for preformatted text
- For lines that start with "<p>" treat these as a paragraph
  start, as was already the case for lines containing only <p>
  and drop these if markup conversion is enabled.
- Don't add a blank line between text and preformatted text
  if the preceding text ends with a colon or a comma.