### PR TITLE
1.5.0: Fix various bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 # KDoc Formatter Changelog
 
+## [1.5.0]
+- A number of bug fixes across the formatter based on running
+  the formatter on some larger code bases and inspecting
+  the results, as well as diffing the HTML output rendered by
+  Dokka.
+- Improved handling for docs with slightly off indentation
+  (e.g. an extra space here and there)
+- Make sure we never break lines in the middle where the
+  next word is ">" (which would be interpreted as a quoted
+  string on the new line) or starts with "@" (which will be
+  interpreted as a (possibly unknown) kdoc tag.)
+- Fix interpretation of nested preformatted text (and revert
+  optimization which skipped blank lines between these)
+- Don't convert @linkplain tags to KDoc references, since Dokka
+  will not render these as {@linkplain}.
+- Handle TODO(string), and numbered lists separated with )
+  instead of .
+- Revert the behavior from 1.4.4 which removed blank lines
+  before preformatted text where the preformatted text was
+  implicit via indentation.
+
 ## [1.4.4]
 - Fix bug in greedy line breaking which meant some lines were
   actually wider than allowed by the line limit

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Options:
   @<filename>
     Read filenames from file.
 
-kdoc-formatter: Version 1.4.4
+kdoc-formatter: Version 1.5.0
 https://github.com/tnorbye/kdoc-formatter
 ```
 

--- a/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormatter.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormatter.kt
@@ -69,7 +69,15 @@ class KDocFileFormatter(private val options: KDocFileFormattingOptions) {
             if (nextIsComment && (file == null || filter.overlaps(file, source, start, end))) {
                 val comment = source.substring(start, end)
                 val indent = getIndent(source, start)
-                val formatted = formatter.reformatComment(comment, indent)
+                val formatted =
+                    try {
+                        formatter.reformatComment(comment, indent)
+                    } catch (error: Throwable) {
+                        System.err.println(
+                            "Failed formatting comment in $file:\n\"\"\"\n$comment\n\"\"\""
+                        )
+                        throw error
+                    }
                 sb.append(formatted)
             } else {
                 val segment = source.substring(start, end)

--- a/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
+++ b/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
@@ -268,7 +268,7 @@ class KDocFileFormatterTest {
             * Can optionally convert various remaining HTML tags in the comments
               to the corresponding KDoc/markdown text. For example, <b>bold</b> is
               converted into **bold**, <p> is converted to a blank line,
-              <h1>Heading</h1> is converted into # Heading, and so on.
+              \<h1>Heading</h1> is converted into # Heading, and so on.
 
             * Support for .editorconfig configuration files to automatically pick
               up line widths. It will normally use the line width configured for
@@ -492,7 +492,7 @@ class KDocFileFormatterTest {
             * Can optionally convert various remaining HTML tags in the comments
               to the corresponding KDoc/markdown text. For example, **bold** is
               converted into **bold**, <p> is converted to a blank line,
-              <h1>Heading</h1> is converted into # Heading, and so on.
+              \<h1>Heading</h1> is converted into # Heading, and so on.
             * Support for .editorconfig configuration files to automatically pick
               up line widths. It will normally use the line width configured for
               Kotlin files, but, if Markdown (.md) files are also configured, it

--- a/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
@@ -5,9 +5,11 @@ import kotlin.math.min
 /** Formatter which can reformat KDoc comments. */
 class KDocFormatter(private val options: KDocFormattingOptions) {
     /**
-     * Reformats the [comment], which follows the given [indent] string.
+     * Reformats the [comment], which follows the given [initialIndent]
+     * string.
      */
-    fun reformatComment(comment: String, indent: String): String {
+    fun reformatComment(comment: String, initialIndent: String): String {
+        @Suppress("UnnecessaryVariable") val indent = initialIndent
         val lineComment = comment.startsWith("//")
         val indentSize = getIndentSize(indent, options)
         val paragraphs = ParagraphListBuilder(comment, options).scan()

--- a/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
@@ -27,13 +27,6 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
     var convertMarkup: Boolean = true
 
     /**
-     * Whether there should **always** be a newline before codeblocks.
-     * When this is not set, we'll as a special case omit the newline if
-     * the previous line ends with ":" or ",".
-     */
-    var alwaysNewLineBeforePreformatted = false
-
-    /**
      * Whether to add punctuation where missing, such as ending
      * sentences with a period. (TODO: Make sure the FIRST sentence
      * ends with one too! Especially if the subsequent sentence is
@@ -51,6 +44,15 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
      * When there are nested lists etc, how many spaces to indent by.
      */
     var nestedListIndent: Int = 3
+        set(value) {
+            if (value < 3) {
+                error(
+                    "Nested list indent must be at least 3; if list items are only indented 2 spaces they " +
+                        "will not be rendered as list items"
+                )
+            }
+            field = value
+        }
 
     /**
      * Don't format with tabs! (See
@@ -84,7 +86,6 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
         copy.collapseSpaces = collapseSpaces
         copy.hangingIndent = hangingIndent
         copy.tabWidth = tabWidth
-        copy.alwaysNewLineBeforePreformatted = alwaysNewLineBeforePreformatted
         return copy
     }
 }

--- a/library/src/main/kotlin/kdocformatter/Utilities.kt
+++ b/library/src/main/kotlin/kdocformatter/Utilities.kt
@@ -35,7 +35,7 @@ fun getLineNumber(source: String, offset: Int, startLine: Int = 1, startOffset: 
     return line
 }
 
-private val numberPattern = Pattern.compile("^\\d+\\. ")
+private val numberPattern = Pattern.compile("^\\d+([.)]) ")
 
 fun String.isListItem(): Boolean {
     return startsWith("- ") ||
@@ -51,7 +51,7 @@ fun String.collapseSpaces(): String {
     }
     val sb = StringBuilder()
     var prev: Char = this[0]
-    for (i in 0 until length) {
+    for (i in indices) {
         if (prev == ' ') {
             if (this[i] == ' ') {
                 continue
@@ -64,7 +64,15 @@ fun String.collapseSpaces(): String {
 }
 
 fun String.isTodo(): Boolean {
-    return startsWith("TODO:")
+    return startsWith("TODO:") || startsWith("TODO(")
+}
+
+fun String.isHeader(): Boolean {
+    return startsWith("#") || startsWith("<h", true)
+}
+
+fun String.isQuoted(): Boolean {
+    return startsWith("> ")
 }
 
 fun String.isDirectiveMarker(): Boolean {

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.4.4
+buildVersion = 1.5.0

--- a/library/src/test/kotlin/kdocformatter/DokkaVerifier.kt
+++ b/library/src/test/kotlin/kdocformatter/DokkaVerifier.kt
@@ -1,0 +1,190 @@
+@file:Suppress("PropertyName", "PrivatePropertyName")
+
+package kdocformatter
+
+import java.io.BufferedReader
+import java.io.File
+import org.junit.jupiter.api.Assertions
+
+/**
+ * Verifies that two KDoc comment strings render to the same HTML
+ * documentation using Dokka. This is used by the test infrastructure to
+ * make sure that the transformations we're allowing are not changing
+ * the appearance of the documentation.
+ *
+ * Unfortunately, just diffing HTML strings isn't always enough, because
+ * dokka will preserve some text formatting which is immaterial to
+ * the HTML appearance. Therefore, if you've also installed Pandoc,
+ * it will use that to generate a text rendering of the HTML which is
+ * then used for diffing instead. (Even this isn't fullproof because
+ * pandoc also preserves some details that should not matter). Text
+ * rendering does drop a lot of markup (such as bold and italics)
+ * so it would be better to compare in some other format, such as
+ * PDF, but unfortunately, the PDF rendering doesn't appear to be
+ * stable; rendering the same document twice yields a binary diff.
+ *
+ * Dokka no longer provides a fat/shadow jar; instead you have
+ * to download a bunch of different dependencies. Therefore, for
+ * convenience this is set up to point to an AndroidX checkout, which
+ * has all the prebuilts. Point the below to AndroidX and the rest
+ * should work.
+ */
+class DokkaVerifier(private val tempFolder: File) {
+    // Configuration parameters
+    // Checkout of https://github.com/androidx/androidx
+    private val ANDROIDX_HOME: String? = null
+
+    // Optional install of pandoc, e.g. "/opt/homebrew/bin/pandoc"
+    private val PANDOC: String? = null
+
+    // JDK install
+    private val JAVA_HOME: String? = System.getenv("JAVA_HOME")
+
+    fun verify(before: String, after: String) {
+        JAVA_HOME ?: return
+        ANDROIDX_HOME ?: return
+
+        val androidx = File(ANDROIDX_HOME)
+        if (!androidx.isDirectory) {
+            return
+        }
+
+        val prebuilts = File(androidx, "prebuilts")
+        if (!prebuilts.isDirectory) {
+            println("AndroidX prebuilts not found; not verifying with Dokka")
+        }
+        val cli = find(prebuilts, "org.jetbrains.dokka", "dokka-cli")
+        val analysis = find(prebuilts, "org.jetbrains.dokka", "dokka-analysis")
+        val base = find(prebuilts, "org.jetbrains.dokka", "dokka-base")
+        val compiler = find(prebuilts, "org.jetbrains.dokka", "kotlin-analysis-compiler")
+        val intellij = find(prebuilts, "org.jetbrains.dokka", "kotlin-analysis-intellij")
+        val coroutines = find(prebuilts, "org.jetbrains.kotlinx", "kotlinx-coroutines-core")
+        val html = find(prebuilts, "org.jetbrains.kotlinx", "kotlinx-html-jvm")
+        val freemarker = find(prebuilts, "org.freemarker", "freemarker")
+
+        val src = File(tempFolder, "src")
+        val out = File(tempFolder, "dokka")
+        src.mkdirs()
+        out.mkdirs()
+
+        val beforeFile = File(src, "before.kt")
+        beforeFile.writeText(
+            "${before.split("\n").joinToString("\n") { it.trim() }}\nclass Before\n"
+        )
+
+        val afterFile = File(src, "after.kt")
+        afterFile.writeText("${after.split("\n").joinToString("\n") { it.trim() }}\nclass After\n")
+
+        val args = mutableListOf<String>()
+        args.add(File(JAVA_HOME, "bin/java").path)
+        args.add("-jar")
+        args.add(cli.path)
+        args.add("-pluginsClasspath")
+        val pathSeparator =
+            ";" // instead of File.pathSeparator as would have been reasonable (e.g. : on Unix)
+        val path =
+            listOf(analysis, base, compiler, intellij, coroutines, html, freemarker).joinToString(
+                    pathSeparator
+                ) { it.path }
+        args.add(path)
+        args.add("-sourceSet")
+        args.add("-src $src") // (nested parameter within -sourceSet)
+        args.add("-outputDir")
+        args.add(out.path)
+        executeProcess(args)
+
+        fun getHtml(file: File): String {
+            val rendered = file.readText()
+            val begin = rendered.indexOf("<div class=\"copy-popup-wrapper popup-to-left\">")
+            val end = rendered.indexOf("<div class=\"tabbedcontent\">", begin)
+            return rendered.substring(begin, end).replace(Regex(" +"), " ").replace(">", ">\n")
+        }
+
+        fun getText(file: File): String? {
+            return if (PANDOC != null) {
+                val pandocFile = File(PANDOC)
+                if (!pandocFile.isFile) {
+                    error("Cannot execute $pandocFile")
+                }
+                val outFile = File(out, "text.text")
+                executeProcess(listOf(PANDOC, file.path, "-o", outFile.path))
+                val rendered = outFile.readText()
+
+                val begin = rendered.indexOf("[]{.copy-popup-icon}Content copied to clipboard")
+                val end = rendered.indexOf("::: tabbedcontent", begin)
+                rendered.substring(begin, end).replace(Regex(" +"), " ").replace(">", ">\n")
+            } else {
+                null
+            }
+        }
+
+        val indexBefore = File("$out/root/[root]/-before/index.html")
+        val beforeContents = getHtml(indexBefore)
+        val indexAfter = File("$out/root/[root]/-after/index.html")
+        val afterContents = getHtml(indexAfter)
+        if (beforeContents != afterContents) {
+            val beforeText = getText(indexBefore)
+            val afterText = getText(indexAfter)
+            if (beforeText != null && afterText != null) {
+                Assertions.assertEquals(beforeText, afterText)
+                return
+            }
+
+            Assertions.assertEquals(beforeContents, afterContents)
+        }
+    }
+
+    private fun find(prebuilts: File, group: String, artifact: String): File {
+        val versionDir = File(prebuilts, "androidx/external/${group.replace('.','/')}/$artifact")
+        val versions =
+            versionDir.listFiles().filter { it.name.first().isDigit() }.sortedByDescending {
+                it.name
+            }
+        for (version in versions.map { it.name }) {
+            val jar = File(versionDir, "$version/$artifact-$version.jar")
+            if (jar.isFile) {
+                return jar
+            }
+        }
+        error("Could not find a valid jar file for $group:$artifact")
+    }
+
+    private fun executeProcess(args: List<String>) {
+        var input: BufferedReader? = null
+        var error: BufferedReader? = null
+        try {
+            val process = Runtime.getRuntime().exec(args.toTypedArray())
+            input = process.inputStream.bufferedReader()
+            error = process.errorStream.bufferedReader()
+            val exitVal = process.waitFor()
+            if (exitVal != 0) {
+                val sb = StringBuilder()
+                sb.append("Failed to execute process\n")
+                sb.append("Command args:\n")
+                for (arg in args) {
+                    sb.append("  ").append(arg).append("\n")
+                }
+                sb.append("Standard output:\n")
+                var line: String?
+                while (input.readLine().also { line = it } != null) {
+                    sb.append(line).append("\n")
+                }
+                sb.append("Error output:\n")
+                while (error.readLine().also { line = it } != null) {
+                    sb.append(line).append("\n")
+                }
+                error(sb.toString())
+            }
+        } catch (t: Throwable) {
+            val sb = StringBuilder()
+            for (arg in args) {
+                sb.append("  ").append(arg).append("\n")
+            }
+            t.printStackTrace()
+            error("Could not run process:\n$sb")
+        } finally {
+            input?.close()
+            error?.close()
+        }
+    }
+}


### PR DESCRIPTION
- A number of bug fixes across the formatter based on running
  the formatter on some larger code bases and inspecting
  the results, as well as diffing the HTML output rendered by
  Dokka.
- Improved handling for docs with slightly off indentation
  (e.g. an extra space here and there)
- Make sure we never break lines in the middle where the
  next word is ">" (which would be interpreted as a quoted
  string on the new line) or starts with "@" (which will be
  interpreted as a (possibly unknown) kdoc tag.)
- Fix interpretation of nested preformatted text (and revert
  optimization which skipped blank lines between these)
- Don't convert @linkplain tags to KDoc references, since Dokka
  will not render these as {@linkplain}.
- Handle TODO(string), and numbered lists separated with )
  instead of .
- Revert the behavior from 1.4.4 which removed blank lines
  before preformatted text where the preformatted text was
  implicit via indentation.