### PR TITLE
1.5.1: Support for tables and doc tag reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 # KDoc Formatter Changelog
 
+## [1.5.1]
+- Support for tables; by default it will realign columns and
+  add edges, but this can be controlled via
+  --align-table-columns and --no-align-table-columns.
+  Horizontal padding is added inside the cells if there is
+  space within the line.
+- Move KDoc tags to the end of comments, and order them
+  (e.g. @param before @return and so on). Can be enabled
+  or disabled with --order-doc-tags and
+  --no-order-doc-tags.
+- Change default maxCommentWidth to 72 (was previously defaulting
+  to the maxLineWidth.)
+- Fix command line driver to properly handle nested
+  string substitutions and to not get confused by single or
+  double quotes backtick quoted function names.
+- Fix a bug where formatting kdocs that started at the end of
+  lines with code was not handled correctly
+- Removed Kotlin logo from the IDE plugin icon
+
 ## [1.5.0]
 - A number of bug fixes across the formatter based on running
   the formatter on some larger code bases and inspecting

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Features
 * Cleans up the double spaces left by the IntelliJ "Convert to
   Kotlin" action right before the closing comment token.
 * Removes trailing spaces.
+* Realigns table columns in Markdown tables and adds padding.
+* Reorders KDoc tags into a canonical order (for example placing
+  @return after @param, and so on.)
 * Can optionally convert various remaining HTML tags in the comments
   to the corresponding KDoc/markdown text. For example, \*\*bold**
   is converted into **bold**, \<p> is converted to a blank line,
@@ -72,7 +75,7 @@ Options:
     you don't want to limit the formatter maximum line width since
     indented code still needs to be properly formatted, but you also
     don't want comments to span 100+ characters, since that's less
-    readable. By default this option is not set.
+    readable. Defaults to 72 (or max-line-width, if set lower than 72.)
   --hanging-indent=<n>
     Sets the number of spaces to use for hanging indents, e.g. second
     and subsequent lines in a bulleted list or kdoc blog tag.
@@ -82,6 +85,15 @@ Options:
     With `collapse`, turns multi-line comments into a single line if it
     fits, and with `expand` it will always format commands with /** and
     */ on their own lines. The default is `collapse`.
+  --align-table-columns
+    Reformat tables such that the |column|separators| line up
+  --no-align-table-columns
+    Do not adjust formatting within table cells
+  --order-doc-tags
+    Move KDoc tags to the end of comments, and order them in a canonical
+    order (@param before @return, and so on)
+  --no-order-doc-tags
+    Do not move or reorder KDoc tagså
   --overlaps-git-changes=<HEAD | staged>
     If git is on the path, and the command is invoked in a git
     repository, kdoc-formatter will invoke git to find the changes either
@@ -103,7 +115,7 @@ Options:
   @<filename>
     Read filenames from file.
 
-kdoc-formatter: Version 1.5.0
+kdoc-formatter: Version 1.5.1
 https://github.com/tnorbye/kdoc-formatter
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ task format(type: JavaExec, group: "verification") {
 }
 
 //ktfmt {
+//    // To format, run ./gradlew ktfmtFormat and then run
+//    // kdoc-formatter --max-line-width=72 --add-punctuation --convert-markup .
 //    kotlinLangStyle()
 //}
 

--- a/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormattingOptions.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormattingOptions.kt
@@ -52,6 +52,12 @@ class KDocFileFormattingOptions {
                         options.formattingOptions.hangingIndent =
                             parseInt(arg.substring("--hanging-indent=".length))
                     arg == "--convert-markup" -> options.formattingOptions.convertMarkup = true
+                    arg == "--align-table-columns" ->
+                        options.formattingOptions.alignTableColumns = true
+                    arg == "--no-align-table-columns" ->
+                        options.formattingOptions.alignTableColumns = false
+                    arg == "--order-doc-tags" -> options.formattingOptions.orderDocTags = true
+                    arg == "--no-order-doc-tags" -> options.formattingOptions.orderDocTags = false
                     arg == "--add-punctuation" -> options.formattingOptions.addPunctuation = true
                     arg.startsWith("--single-line-comments=collapse") ->
                         options.formattingOptions.collapseSingleLine = true
@@ -145,7 +151,7 @@ class KDocFileFormattingOptions {
                 you don't want to limit the formatter maximum line width since
                 indented code still needs to be properly formatted, but you also
                 don't want comments to span 100+ characters, since that's less
-                readable. By default this option is not set.
+                readable. Defaults to 72 (or max-line-width, if set lower than 72.)
               --hanging-indent=<n>
                 Sets the number of spaces to use for hanging indents, e.g. second
                 and subsequent lines in a bulleted list or kdoc blog tag.
@@ -158,6 +164,15 @@ class KDocFileFormattingOptions {
                 With `collapse`, turns multi-line comments into a single line if it
                 fits, and with `expand` it will always format commands with /** and
                 */ on their own lines. The default is `collapse`.
+              --align-table-columns
+                Reformat tables such that the |column|separators| line up
+              --no-align-table-columns
+                Do not adjust formatting within table cells
+              --order-doc-tags
+                Move KDoc tags to the end of comments, and order them in a canonical
+                order (@param before @return, and so on)
+              --no-order-doc-tags
+                Do not move or reorder KDoc tagså
               --overlaps-git-changes=<HEAD | staged>
                 If git is on the path, and the command is invoked in a git
                 repository, kdoc-formatter will invoke git to find the changes either

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
@@ -19,6 +19,8 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
   private val convertMarkupCheckBox = JBCheckBox("Convert markup like <b>bold</b> into **bold**")
   private val addPunctuationCheckBox = JBCheckBox("Add missing punctuation")
   private val lineCommentsCheckBox = JBCheckBox("Allow formatting line comments interactively")
+  private val alignTableColumnsCheckBox = JBCheckBox("Align table columns")
+  private val reorderKDocTagsCheckBox = JBCheckBox("Move and reorder KDoc tags")
 
   private val state = KDocPluginOptions.instance.globalState
 
@@ -29,6 +31,8 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     row { convertMarkupCheckBox() }
     row { addPunctuationCheckBox() }
     row { lineCommentsCheckBox() }
+    row { alignTableColumnsCheckBox() }
+    row { reorderKDocTagsCheckBox() }
   }
 
   override fun isModified() =
@@ -37,7 +41,9 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
           convertMarkupCheckBox.isSelected != state.convertMarkup ||
           lineCommentsCheckBox.isSelected != state.lineComments ||
           addPunctuationCheckBox.isSelected != state.addPunctuation ||
-          formatProcessorCheckBox.isSelected != state.formatProcessor
+          formatProcessorCheckBox.isSelected != state.formatProcessor ||
+          alignTableColumnsCheckBox.isSelected != state.alignTableColumns ||
+          reorderKDocTagsCheckBox.isSelected != state.reorderDocTags
 
   @Throws(ConfigurationException::class)
   override fun apply() {
@@ -47,6 +53,8 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     state.lineComments = lineCommentsCheckBox.isSelected
     state.addPunctuation = addPunctuationCheckBox.isSelected
     state.formatProcessor = formatProcessorCheckBox.isSelected
+    state.alignTableColumns = alignTableColumnsCheckBox.isSelected
+    state.reorderDocTags = reorderKDocTagsCheckBox.isSelected
   }
 
   override fun reset() {
@@ -56,5 +64,7 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     lineCommentsCheckBox.isSelected = state.lineComments
     addPunctuationCheckBox.isSelected = state.addPunctuation
     formatProcessorCheckBox.isSelected = state.formatProcessor
+    alignTableColumnsCheckBox.isSelected = state.alignTableColumns
+    reorderKDocTagsCheckBox.isSelected = state.reorderDocTags
   }
 }

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocPluginOptions.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocPluginOptions.kt
@@ -46,6 +46,8 @@ class KDocPluginOptions : PersistentStateComponent<KDocPluginOptions.ComponentSt
     var lineComments = false
     var addPunctuation = false
     var formatProcessor = true
+    var alignTableColumns = true
+    var reorderDocTags = true
   }
 
   companion object {

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
@@ -324,5 +324,7 @@ fun getKDocFormattingOptions(
   configOptions.convertMarkup = state.convertMarkup
   configOptions.alternate = alternate
   configOptions.addPunctuation = state.addPunctuation
+  configOptions.alignTableColumns = state.alignTableColumns
+  configOptions.orderDocTags = state.reorderDocTags
   return configOptions
 }

--- a/ide-plugin/src/main/resources/META-INF/pluginIcon.svg
+++ b/ide-plugin/src/main/resources/META-INF/pluginIcon.svg
@@ -1,21 +1,125 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg enable-background="new 0 0 500 500" version="1.1" viewBox="0 0 600 600" xml:space="preserve"
-     xmlns="http://www.w3.org/2000/svg">
-<style type="text/css">
-	.st0{fill:url(#a);}
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 500 500"
+   style="enable-background:new 0 0 500 500;"
+   xml:space="preserve"
+   sodipodi:docname="kdoc-formatter5.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs19"><linearGradient
+     inkscape:collect="always"
+     id="linearGradient3654"><stop
+       style="stop-color:#d100ff;stop-opacity:1;"
+       offset="0"
+       id="stop3650" /><stop
+       style="stop-color:#d100ff;stop-opacity:0;"
+       offset="1"
+       id="stop3652" /></linearGradient><linearGradient
+     id="linearGradient3624"
+     inkscape:swatch="solid"><stop
+       style="stop-color:#d100ff;stop-opacity:1;"
+       offset="0"
+       id="stop3622" /></linearGradient><rect
+     x="180.46918"
+     y="128.48386"
+     width="211.91988"
+     height="293.25706"
+     id="rect2435" /><linearGradient
+     inkscape:collect="always"
+     xlink:href="#linearGradient3654"
+     id="linearGradient3656"
+     x1="26.050117"
+     y1="248.31905"
+     x2="477.26923"
+     y2="248.31905"
+     gradientUnits="userSpaceOnUse"
+     gradientTransform="translate(2.6172442,0.51539393)" /></defs><sodipodi:namedview
+   id="namedview17"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="1.596"
+   inkscape:cx="104.94987"
+   inkscape:cy="248.43358"
+   inkscape:window-width="1920"
+   inkscape:window-height="995"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:url(#SVGID_1_);}
 </style>
-<linearGradient id="a" x1="500" x2="-.096538" y1="579.11" y2="1079.2"
-                gradientTransform="matrix(.9998 0 0 .9998 .096519 -578.99)" gradientUnits="userSpaceOnUse">
-        <stop stop-color="#E44857" offset=".0034351"/>
-    <stop stop-color="#C711E1" offset=".4689"/>
-    <stop stop-color="#7F52FF" offset="1"/>
-    </linearGradient>
-<polygon class="st0" points="500 500 0 500 0 0 500 0 250 250"/>
-<text fill="black" font-family="sans-serif" font-size="40px"
-      style="line-height:1.25;shape-inside:url(#rect2435);white-space:pre" xml:space="preserve"/>
-<text x="243.38821" y="618.81024" fill="#000000" font-family="Roboto" font-size="533.33px" font-weight="900"
-      style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal;line-height:1.25"
-      xml:space="preserve"><tspan x="243.38821" y="618.81024">*</tspan></text>
-<text x="125.939" y="462.70602" fill="#000000" font-family="Roboto" font-size="426.67px" font-weight="900"
-      style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal;line-height:1.25"
-      xml:space="preserve"><tspan x="125.939" y="462.70602">/</tspan></text></svg>
+<rect
+   style="fill:url(#linearGradient3656);fill-opacity:1;fill-rule:evenodd"
+   id="rect121"
+   width="451.21912"
+   height="370.59314"
+   x="28.667368"
+   y="63.537888" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:426.667px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none"
+   x="106.98609"
+   y="382.31848"
+   id="text14770"><tspan
+     sodipodi:role="line"
+     id="tspan14974"
+     x="106.98609"
+     y="382.31848">/</tspan></text><g
+   id="Logotypes">
+	<g
+   id="g13">
+		
+			<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="500.0035"
+   y1="579.1058"
+   x2="-9.653803e-02"
+   y2="1079.2058"
+   gradientTransform="matrix(0.9998 0 0 0.9998 9.651873e-02 -578.99)">
+			<stop
+   offset="3.435144e-03"
+   style="stop-color:#E44857"
+   id="stop4" />
+			<stop
+   offset="0.4689"
+   style="stop-color:#C711E1"
+   id="stop6" />
+			<stop
+   offset="1"
+   style="stop-color:#7F52FF"
+   id="stop8" />
+		</linearGradient>
+		
+	</g>
+</g>
+<text
+   xml:space="preserve"
+   id="text2433"
+   style="fill:black;fill-opacity:1;line-height:1.25;stroke:none;font-family:sans-serif;font-style:normal;font-weight:normal;font-size:40px;white-space:pre;shape-inside:url(#rect2435)" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:533.333px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none"
+   x="216.19177"
+   y="517.58594"
+   id="text2947"><tspan
+     sodipodi:role="line"
+     id="tspan16684"
+     x="216.19177"
+     y="517.58594">*</tspan></text></svg>

--- a/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
@@ -12,7 +12,7 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
         @Suppress("UnnecessaryVariable") val indent = initialIndent
         val lineComment = comment.startsWith("//")
         val indentSize = getIndentSize(indent, options)
-        val paragraphs = ParagraphListBuilder(comment, options).scan()
+        val paragraphs = ParagraphListBuilder(comment, options).scan(indentSize)
         val lineSeparator =
             if (lineComment) {
                 "\n$indent// "
@@ -50,7 +50,7 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
                 sb.append(lineSeparator)
             }
             val text = paragraph.text
-            if (paragraph.preformatted) {
+            if (paragraph.preformatted || paragraph.table) {
                 sb.append(text)
                 // Remove trailing spaces which can happen when we
                 // have an empty line in a preformatted paragraph.

--- a/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
@@ -1,16 +1,17 @@
 package kdocformatter
 
-/** Options controlling how the [KDocFormatter] will behave. */
-class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integer.MAX_VALUE) {
-    /** Right hand side margin to write lines at. */
-    @Suppress("CanBePrimaryConstructorProperty") var maxLineWidth: Int = maxLineWidth
+import kotlin.math.min
 
+/** Options controlling how the [KDocFormatter] will behave. */
+class KDocFormattingOptions(
+    /** Right hand side margin to write lines at. */
+    var maxLineWidth: Int = 72,
     /**
      * Limit comment to be at most [maxCommentWidth] characters even if
      * more would fit on the line.
      */
-    @Suppress("CanBePrimaryConstructorProperty") var maxCommentWidth: Int = maxCommentWidth
-
+    var maxCommentWidth: Int = min(maxLineWidth, 72)
+) {
     /**
      * Whether to collapse multi-line comments that would fit on a
      * single line into a single line.
@@ -68,6 +69,19 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
     var optimal: Boolean = true
 
     /**
+     * If true, reformat markdown tables such that the column markers
+     * line up. When false, markdown tables are left alone (except for
+     * left hand side cleanup.)
+     */
+    var alignTableColumns: Boolean = true
+
+    /**
+     * If true, moves any kdoc tags to the end of the comment and
+     * `@return` tags after `@param` tags.
+     */
+    var orderDocTags: Boolean = true
+
+    /**
      * If true, perform "alternative" formatting. This is only relevant
      * in the IDE. You can invoke the action repeatedly and it will
      * jump between normal formatting an alternative formatting.
@@ -86,6 +100,8 @@ class KDocFormattingOptions(maxLineWidth: Int = 72, maxCommentWidth: Int = Integ
         copy.collapseSpaces = collapseSpaces
         copy.hangingIndent = hangingIndent
         copy.tabWidth = tabWidth
+        copy.alignTableColumns = alignTableColumns
+        copy.orderDocTags = orderDocTags
         return copy
     }
 }

--- a/library/src/main/kotlin/kdocformatter/Paragraph.kt
+++ b/library/src/main/kotlin/kdocformatter/Paragraph.kt
@@ -46,6 +46,9 @@ class Paragraph(private val options: KDocFormattingOptions) {
      */
     var quoted = false
 
+    /** Is this line part of a table? */
+    var table = false
+
     /**
      * Should this paragraph use a hanging indent? (Implies [block] as
      * well).
@@ -320,6 +323,8 @@ class Paragraph(private val options: KDocFormattingOptions) {
         for (i in start until words.size) {
             val word = words[i]
 
+            // We also cannot break up a URL text across lines, which will alter
+            // the rendering of the docs.
             if (prev.startsWith("[")) insideSquareBrackets = true
             if (prev.contains("]")) insideSquareBrackets = false
 

--- a/library/src/main/kotlin/kdocformatter/Table.kt
+++ b/library/src/main/kotlin/kdocformatter/Table.kt
@@ -1,0 +1,263 @@
+package kdocformatter
+
+import kotlin.math.max
+
+class Table(
+    private val columns: Int,
+    private val widths: List<Int>,
+    private val rows: List<Row>,
+    private val align: List<Align>,
+    private val original: List<String>
+) {
+    fun original(): List<String> {
+        return original
+    }
+
+    /**
+     * Format the table. Note that table rows cannot be broken into
+     * multiple lines in Markdown tables, so the [maxWidth] here is used
+     * to decide whether to add padding around the table only, and it's
+     * quite possible for the table to format to wider lengths than
+     * [maxWidth].
+     */
+    fun format(maxWidth: Int = Integer.MAX_VALUE): List<String> {
+        val tableMaxWidth =
+            2 + widths.sumOf { it + 2 } // +2: "| " in each cell and final " |" on the right
+
+        val pad = tableMaxWidth <= maxWidth
+        val lines = mutableListOf<String>()
+        for (i in rows.indices) {
+            val sb = StringBuilder()
+            val row = rows[i]
+            for (column in 0 until row.cells.size) {
+                sb.append('|')
+                if (pad) {
+                    sb.append(' ')
+                }
+                val cell = row.cells[column]
+                val width = widths[column]
+                val s =
+                    if (align[column] == Align.CENTER && i > 0) {
+                        String.format(
+                            "%-${width}s",
+                            String.format("%${cell.length + (width - cell.length) / 2}s", cell)
+                        )
+                    } else if (align[column] == Align.RIGHT && i > 0) {
+                        String.format("%${width}s", cell)
+                    } else {
+                        String.format("%-${width}s", cell)
+                    }
+                sb.append(s)
+                if (pad) {
+                    sb.append(' ')
+                }
+            }
+            sb.append('|')
+            lines.add(sb.toString())
+            sb.clear()
+
+            if (i == 0) {
+                for (column in 0 until row.cells.size) {
+                    sb.append('|')
+                    var width = widths[column]
+                    if (align[column] != Align.LEFT) {
+                        width--
+                        if (align[column] == Align.CENTER) {
+                            sb.append(':')
+                            width--
+                        }
+                    }
+                    if (pad) {
+                        sb.append('-')
+                    }
+                    val s = "-".repeat(width)
+                    sb.append(s)
+                    if (pad) {
+                        sb.append('-')
+                    }
+                    if (align[column] != Align.LEFT) {
+                        sb.append(':')
+                    }
+                }
+                sb.append('|')
+                lines.add(sb.toString())
+                sb.clear()
+            }
+        }
+
+        return lines
+    }
+
+    companion object {
+        /**
+         * If the line starting at index [start] begins a table, return
+         * that table as well as the index of the first line after the
+         * table.
+         */
+        fun getTable(
+            lines: List<String>,
+            start: Int,
+            lineContent: (String) -> String
+        ): Pair<Table, Int>? {
+            if (start > lines.size - 2) {
+                return null
+            }
+            val headerLine = lineContent(lines[start])
+            val separatorLine = lineContent(lines[start + 1])
+            val barCount = countSeparators(headerLine)
+            if (!isHeaderDivider(barCount, separatorLine.trim())) {
+                return null
+            }
+            val header = getRow(headerLine) ?: return null
+            val rows = mutableListOf<Row>()
+            rows.add(header)
+
+            val dividerRow = getRow(separatorLine) ?: return null
+
+            var i = start + 2
+            while (i < lines.size) {
+                val line = lineContent(lines[i])
+                if (!line.contains("|")) {
+                    break
+                }
+                val row = getRow(line) ?: break
+                rows.add(row)
+                i++
+            }
+
+            val rowsAndDivider = rows + dividerRow
+            if (rowsAndDivider.all {
+                    val first = it.cells.firstOrNull()
+                    first != null && first.isBlank()
+                }
+            ) {
+                rowsAndDivider.forEach { if (it.cells.isNotEmpty()) it.cells.removeAt(0) }
+            }
+
+            // val columns = rows.maxOf { it.cells.size }
+            val columns = dividerRow.cells.size
+            val maxColumns = rows.maxOf { it.cells.size }
+            val widths = mutableListOf<Int>()
+            for (column in 0 until maxColumns) {
+                widths.add(3)
+            }
+            for (row in rows) {
+                for (column in 0 until row.cells.size) {
+                    widths[column] = max(widths[column], row.cells[column].length)
+                }
+                for (column in row.cells.size until columns) {
+                    row.cells.add("")
+                }
+            }
+
+            val align = mutableListOf<Align>()
+            for (cell in dividerRow.cells) {
+                val direction =
+                    if (cell.endsWith(":")) {
+                        if (cell.startsWith(":-")) {
+                            Align.CENTER
+                        } else {
+                            Align.RIGHT
+                        }
+                    } else {
+                        Align.LEFT
+                    }
+                align.add(direction)
+            }
+            for (column in align.size until maxColumns) {
+                align.add(Align.LEFT)
+            }
+            val table =
+                Table(columns, widths, rows, align, lines.subList(start, i).map { lineContent(it) })
+            return Pair(table, i)
+        }
+
+        /**
+         * Returns true if the given String looks like a markdown table
+         * header divider.
+         */
+        private fun isHeaderDivider(barCount: Int, s: String): Boolean {
+            var i = 0
+            var count = 0
+            while (i < s.length) {
+                val c = s[i++]
+                if (c == '\\') {
+                    i++
+                } else if (c == '|') {
+                    count++
+                } else if (c.isWhitespace() || c == ':') {
+                    continue
+                } else if (c == '-' &&
+                        (s.startsWith("--", i) ||
+                            s.startsWith("-:", i) ||
+                            i > 1 && s.startsWith(":-:", i - 2) ||
+                            i > 1 && s.startsWith(":--", i - 2))
+                ) {
+                    while (i < s.length && s[i] == '-') {
+                        i++
+                    }
+                } else {
+                    return false
+                }
+            }
+
+            return barCount == count
+        }
+
+        private fun getRow(s: String): Row? {
+            // Can't just use String.split('|') because that would not handle escaped |'s
+            if (s.indexOf('|') == -1) {
+                return null
+            }
+            val row = Row()
+            var i = 0
+            var end = 0
+            while (end < s.length) {
+                val c = s[end]
+                if (c == '\\') {
+                    end++
+                } else if (c == '|') {
+                    val cell = s.substring(i, end).trim()
+                    if (end > 0) {
+                        row.cells.add(cell.trim())
+                    }
+                    i = end + 1
+                }
+                end++
+            }
+            if (end > i) {
+                val cell = s.substring(i, end).trim()
+                if (cell.isNotEmpty()) {
+                    row.cells.add(cell.trim())
+                }
+            }
+
+            return row
+        }
+
+        private fun countSeparators(s: String): Int {
+            var i = 0
+            var count = 0
+            while (i < s.length) {
+                val c = s[i]
+                if (c == '|') {
+                    count++
+                } else if (c == '\\') {
+                    i++
+                }
+                i++
+            }
+            return count
+        }
+    }
+
+    enum class Align {
+        LEFT,
+        RIGHT,
+        CENTER
+    }
+
+    class Row {
+        val cells = mutableListOf<String>()
+    }
+}

--- a/library/src/main/kotlin/kdocformatter/Utilities.kt
+++ b/library/src/main/kotlin/kdocformatter/Utilities.kt
@@ -89,29 +89,19 @@ fun String.isExpectingMore(): Boolean {
 }
 
 fun String.isKDocTag(): Boolean {
-    if (!startsWith("@")) {
-        return false
+    // Not using a hardcoded list here since tags can change over time
+    if (startsWith("@")) {
+        for (i in 1 until length) {
+            val c = this[i]
+            if (c.isWhitespace()) {
+                return i > 2
+            } else if (!c.isLetter() || !c.isLowerCase()) {
+                return false
+            }
+        }
+        return true
     }
-    // Match actual set of kdoc tags instead of just "@something" such that we
-    // don't accidentally interpret docs that contain for example annotation names
-    // as block tags. (See KDocFormatterTest.testAtInMiddle for an example
-    // which was affected by this.)
-    // (See https://kotlinlang.org/docs/reference/kotlin-doc.html#block-tags)
-    return startsWith("@param") ||
-        startsWith("@param") ||
-        startsWith("@return") ||
-        startsWith("@constructor") ||
-        startsWith("@receiver") ||
-        startsWith("@property") ||
-        startsWith("@throws") ||
-        startsWith("@exception") ||
-        startsWith("@sample") ||
-        startsWith("@see") ||
-        startsWith("@author") ||
-        startsWith("@since") ||
-        startsWith("@suppress") ||
-        // Not an actual kdoc tag but might appear in converted docs
-        startsWith("@deprecated")
+    return false
 }
 
 /**

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.5.0
+buildVersion = 1.5.1


### PR DESCRIPTION
- Support for tables; by default it will realign columns and
  add edges, but this can be controlled via
  --align-table-columns and --no-align-table-columns.
  Horizontal padding is added inside the cells if there is
  space within the line.
- Move KDoc tags to the end of comments, and order them
  (e.g. @param before @return and so on). Can be enabled
  or disabled with --order-doc-tags and
  --no-order-doc-tags.
- Change default maxCommentWidth to 72 (was previously defaulting
  to the maxLineWidth.)
- Fix command line driver to properly handle nested
  string substitutions and to not get confused by single or
  double quotes backtick quoted function names.
- Fix a bug where formatting kdocs that started at the end of
  lines with code was not handled correctly
- Removed Kotlin logo from the IDE plugin icon