### PR TITLE
1.5.2: Allow IDE plugin to configure maxCommentWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # KDoc Formatter Changelog
 
+## [1.5.2]
+- Updates to the IDE plugin to allow configuring maxCommentWidth
+  behavior. Fixes https://github.com/tnorbye/kdoc-formatter/issues/53
+
 ## [1.5.1]
 - Support for tables; by default it will realign columns and
   add edges, but this can be controlled via

--- a/ide-plugin/CHANGELOG.md
+++ b/ide-plugin/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 # KDoc Formatter Plugin Changelog
 
+## [1.5.2]
+- Adds a new option which lets you turn off the concept
+  of a separate maximum comment width from the maximum
+  line width. By default, comments are limited to 72
+  characters wide (or more accurately the configured width
+  for Markdown files), which leads to more readable text.
+  However, if you really want the full line width to be
+  used, uncheck the "Allow max comment width to be separate
+  from line width" setting.
+- Fixes bug to ensure the line width and max comment width
+  are properly read from the IDE environment settings.
+
 ## [1.5.1]
 - Updated formatter with many bug fixes, as well as improved support
   for formatting tables as well as reordering KDoc tags. There are new

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.layout.panel
+import com.intellij.util.ui.UIUtil
 import org.jetbrains.annotations.Nls
 
 class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
@@ -21,6 +22,8 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
   private val lineCommentsCheckBox = JBCheckBox("Allow formatting line comments interactively")
   private val alignTableColumnsCheckBox = JBCheckBox("Align table columns")
   private val reorderKDocTagsCheckBox = JBCheckBox("Move and reorder KDoc tags")
+  private val maxCommentWidthEnabledCheckBox =
+      JBCheckBox("Allow max comment width to be separate from line width")
 
   private val state = KDocPluginOptions.instance.globalState
 
@@ -33,6 +36,14 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     row { lineCommentsCheckBox() }
     row { alignTableColumnsCheckBox() }
     row { reorderKDocTagsCheckBox() }
+    row { label("") }
+    row { maxCommentWidthEnabledCheckBox() }
+    row {
+      label(
+          "When checked, comments will be limited 72 characters (or the configured Markdown line length),\n" +
+              "for improved readability. Otherwise, comments will use the full available line width.",
+          style = UIUtil.ComponentStyle.SMALL)
+    }
   }
 
   override fun isModified() =
@@ -43,7 +54,8 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
           addPunctuationCheckBox.isSelected != state.addPunctuation ||
           formatProcessorCheckBox.isSelected != state.formatProcessor ||
           alignTableColumnsCheckBox.isSelected != state.alignTableColumns ||
-          reorderKDocTagsCheckBox.isSelected != state.reorderDocTags
+          reorderKDocTagsCheckBox.isSelected != state.reorderDocTags ||
+          maxCommentWidthEnabledCheckBox.isSelected != state.maxCommentWidthEnabled
 
   @Throws(ConfigurationException::class)
   override fun apply() {
@@ -55,6 +67,7 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     state.formatProcessor = formatProcessorCheckBox.isSelected
     state.alignTableColumns = alignTableColumnsCheckBox.isSelected
     state.reorderDocTags = reorderKDocTagsCheckBox.isSelected
+    state.maxCommentWidthEnabled = maxCommentWidthEnabledCheckBox.isSelected
   }
 
   override fun reset() {
@@ -66,5 +79,6 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     formatProcessorCheckBox.isSelected = state.formatProcessor
     alignTableColumnsCheckBox.isSelected = state.alignTableColumns
     reorderKDocTagsCheckBox.isSelected = state.reorderDocTags
+    maxCommentWidthEnabledCheckBox.isSelected = state.maxCommentWidthEnabled
   }
 }

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocPluginOptions.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocPluginOptions.kt
@@ -48,6 +48,7 @@ class KDocPluginOptions : PersistentStateComponent<KDocPluginOptions.ComponentSt
     var formatProcessor = true
     var alignTableColumns = true
     var reorderDocTags = true
+    var maxCommentWidthEnabled = true
   }
 
   companion object {

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.5.1
+buildVersion = 1.5.2


### PR DESCRIPTION
- Adds a new option which lets you turn off the concept
  of a separate maximum comment width from the maximum
  line width. By default, comments are limited to 72
  characters wide (or more accurately the configured width
  for Markdown files), which leads to more readable text.
  However, if you really want the full line width to be
  used, uncheck the "Allow max comment width to be separate
  from line width" setting.
- Fixes bug to ensure the line width and max comment width
  are properly read from the IDE environment settings.