### PR TITLE
1.5.5: Bug fixes, IDE plugin improvements, block comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 # KDoc Formatter Changelog
 
+## [1.5.5]
+- Fixed the following bugs:
+   - #53: The collapse-single-line setting does not work in the IDE
+   - #69: Paragraph + list (stability), variation 2
+   - #70: Multi-line @link isn't converted if there's a #
+   - #71: Make plugin dynamic
+   - #72: @param with brackets is not supported
+   - A bug where `<p>` paragraphs following a blank line would be
+     deleted (without leaving a blank paragraph separator)
+- Changed heuristics around optimal or greedy line breaking in list
+  items and for KDoc tag and TODO-item paragraph formatting.
+- The .editorconfig support is improved. It will now pick up the nearest
+  applicable .editorconfig settings for a file, but any options
+  explicitly set from the command line will override the .editor config.
+   - Also, the "collapse documents that fit on a single line" option,
+     instead of just defaulting to true, will now use the default
+     specified for the equivalent setting for Java (if set), ensuring a
+     more consistent codebase. (You can also set it for Kotlin using
+     `ij_kotlin_doc_do_not_wrap_if_one_line`, though that option isn't
+     supported in the IDE or by the Kotlin plugin currently.)
+- Preliminary support for formatting line comments and block comments
+  (enabled via new flags, `--include-line-comments` and
+  `--include-block-comments`.)
+- Misc IDE plugin improvements
+- `<pre>` tags are converted into KDoc preformatted blocks
+
 ## [1.5.4]
 - Fix 9 bugs filed by the ktfmt project.
 
@@ -19,37 +45,37 @@
 ## [1.5.1]
 - Support for tables; by default it will realign columns and add edges,
   but this can be controlled via --align-table-columns and
-  --no-align-table-columns. Horizontal padding is added
-  inside the cells if there is space within the line.
+  --no-align-table-columns. Horizontal padding is added inside the cells
+  if there is space within the line.
 - Move KDoc tags to the end of comments, and order them (e.g. @param
-  before @return and so on). Can be enabled or disabled
-  with --order-doc-tags and --no-order-doc-tags.
+  before @return and so on). Can be enabled or disabled with
+  --order-doc-tags and --no-order-doc-tags.
 - Change default maxCommentWidth to 72 (was previously defaulting to the
   maxLineWidth.)
 - Fix command line driver to properly handle nested string substitutions
-  and to not get confused by single or double
-  quotes backtick quoted function names.
+  and to not get confused by single or double quotes backtick quoted
+  function names.
 - Fix a bug where formatting kdocs that started at the end of lines with
   code was not handled correctly
 
 ## [1.5.0]
 - A number of bug fixes across the formatter based on running the
-  formatter on some larger code bases and inspecting the
-  results, as well as diffing the HTML output rendered by Dokka.
+  formatter on some larger code bases and inspecting the results, as
+  well as diffing the HTML output rendered by Dokka.
 - Improved handling for docs with slightly off indentation (e.g. an
   extra space here and there)
 - Make sure we never break lines in the middle where the next word is
-  ">" (which would be interpreted as a quoted string
-  on the new line) or starts with "@" (which will
-  be interpreted as a (possibly unknown) kdoc tag.)
+  ">" (which would be interpreted as a quoted string on the new line) or
+  starts with "@" (which will be interpreted as a (possibly unknown)
+  kdoc tag.)
 - Fix interpretation of nested preformatted text (and revert
   optimization which skipped blank lines between these)
 - Don't convert @linkplain tags to KDoc references, since Dokka will not
   render these as {@linkplain}.
 - Handle TODO(string), and numbered lists separated with ) instead of .
 - Revert the behavior from 1.4.4 which removed blank lines before
-  preformatted text where the preformatted
-  text was implicit via indentation.
+  preformatted text where the preformatted text was implicit via
+  indentation.
 
 ## [1.4.4]
 - Fix bug in greedy line breaking which meant some lines were actually
@@ -57,8 +83,8 @@
 - Skip markup tag conversion for text inside `backticks` as was already
   done for preformatted text
 - For lines that start with "<p>" treat these as a paragraph start, as
-  was already the case for lines containing only <p>
-  and drop these if markup conversion is enabled.
+  was already the case for lines containing only <p> and drop these if
+  markup conversion is enabled.
 - Don't add a blank line between text and preformatted text if the
   preceding text ends with a colon or a comma.
 
@@ -75,15 +101,15 @@
 
 ## [1.4.0]
 - The IntelliJ plugin now applies KDoc formatting as part of regular
-  formatting (Code > Format Code), not just
-  via an explicit action. This is optional.
+  formatting (Code > Format Code), not just via an explicit action. This
+  is optional.
 - The markup conversion (if enabled) now converts [] and {@linkplain}
   tags to the KDoc equivalent.
 - Fix bug where preformatted text immediately following a TODO comment
   would be joined into the TODO.
 - Internally, updated from Java 8 and Kotlin 1.4 to Java 11 and Kotlin
-  1.6, various other dependencies, fixed some deprecations,
-  and upgraded the plugin build and change log build scripts.
+  1.6, various other dependencies, fixed some deprecations, and upgraded
+  the plugin build and change log build scripts.
 
 ## [1.3.3]
 - Bug fix: Avoid line wrapping for text inside square brackets,
@@ -96,13 +122,13 @@
 
 ## [1.3.1]
 - Fixes a few bugs around markup conversion not producing the right
-  number of blank lines for a <p>, and adds a few more
-  prefixes as non-breakable (e.g. if you have an em
-  dash in your sentence -- like this -- we don't want
-  the "--" to be placed at the beginning of a line.)
+  number of blank lines for a <p>, and adds a few more prefixes as
+  non-breakable (e.g. if you have an em dash in your sentence -- like
+  this -- we don't want the "--" to be placed at the beginning of a
+  line.)
 - Adds an --add-punctuation command line flag and IDE setting to
-  optionally add closing periods on capitalized
-  paragraphs at the end of the comment.
+  optionally add closing periods on capitalized paragraphs at the end of
+  the comment.
 - Special cases TODO: comments (placing them in a block by themselves
   and using hanging indents).
 
@@ -110,18 +136,18 @@
 - Many improves to the markdown handling, such as quoted blocks,
   headers, list continuations, etc.
 - Markup conversion, which until this point could convert inline tags
-  such as **bold** into **bold**, etc, now handles
-  many block level tags too, such as \<p>, \<h1>, etc.
+  such as **bold** into **bold**, etc, now handles many block level tags
+  too, such as \<p>, \<h1>, etc.
 - The IDE plugin can now also reformat line comments under the caret.
   (This is opt-in via options.)
 
 ## [1.2.0]
 - This version adds a settings panel to the IDE plugin where you can
-  configure whether the plugin will alternate formatting
-  modes on repeated invocation, as well as whether single
-  line comments should be collapsed and whether to convert
-  markup like bold to bold. (Note that line lengths will just
-  use the IDE code style settings or .editorconfig files).
+  configure whether the plugin will alternate formatting modes on
+  repeated invocation, as well as whether single line comments should be
+  collapsed and whether to convert markup like bold to bold. (Note that
+  line lengths will just use the IDE code style settings or
+  .editorconfig files).
 - It also improves the code which preserves the caret across formatting
   actions to be a bit more accurate.
 
@@ -138,8 +164,8 @@
 
 ## [1.1.0]
 - This version adds support for --max-comment-width, and for the Gradle
-  plugin to be able to supply options (via kdocformatter.options
-  = "--max-line-width=100 --max-comment-width=72" etc.)
+  plugin to be able to supply options (via kdocformatter.options =
+  "--max-line-width=100 --max-comment-width=72" etc.)
 - It changes the Gradle plugin group id (since the previous one was
   rejected by Sonatype) and tweaks a few minor things.
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ too long or too short:
 Features
 --------
 * Reflow using optimal instead of greedy algorithm (though in the IDE
-  plugin you can turn on alternate formatting and invoking
-  the action repeatedly alternates between the two modes.)
+  plugin you can turn on alternate formatting and invoking the action
+  repeatedly alternates between the two modes.)
 * Command line script which can recursively format a whole source
   folder.
 * IDE plugin to format selected files or current comment. Preserves
-  caret position in the current comment.
-  Also hooks into the IDE formatting action.
+  caret position in the current comment. Also hooks into the IDE
+  formatting action.
 * Gradle plugin to format the source folders in the current project.
 * Block tags (like @param) are separated out from the main text, and
   subsequent lines are indented. Blank spaces between doc tags are
@@ -45,74 +45,82 @@ Features
 * Realigns table columns in Markdown tables and adds padding.
 * Reorders KDoc tags into a canonical order (for example placing
 * Can optionally convert various remaining HTML tags in the comments to
-  the corresponding KDoc/markdown text. For example, \*\*bold**
-  is converted into **bold**, \<p> is converted to a blank line,
+  the corresponding KDoc/markdown text. For example, \*\*bold** is
+  converted into **bold**, \<p> is converted to a blank line,
   \<h1>Heading\</h1> is converted into # Heading, and so on.
 * Support for .editorconfig configuration files to automatically pick up
-  line widths. It will normally use the line width configured for
-  Kotlin files, but, if Markdown (.md) files are also configured, it
-  will use that width as the maximum comment width. This allows you
-  to have code line widths of for example 140 but limit comments to
-  70 characters (possibly indented). For code, avoiding line breaking
-  is helpful, but for text, shorter lines are better for reading.
+  line widths. It will normally use the line width configured for Kotlin
+  files, but, if Markdown (.md) files are also configured, it will use
+  that width as the maximum comment width. This allows you to have code
+  line widths of for example 140 but limit comments to 70 characters
+  (possibly indented). For code, avoiding line breaking is helpful, but
+  for text, shorter lines are better for reading.
 
 Command Usage
 -------------
-
 ```
 $ kdoc-formatter
 Usage: kdoc-formatter [options] file(s)
 
 Options:
-  --max-line-width=<n>
-    Sets the length of lines. Defaults to 72.
-  --max-comment-width=<n>
+--max-line-width=<n>
+     Sets the length of lines. Defaults to 72.
+--max-comment-width=<n>
     Sets the maximum width of comments. This is helpful in a codebase
-    with large line lengths, such as 140 in the IntelliJ codebase. Here,
-    you don't want to limit the formatter maximum line width since
-    indented code still needs to be properly formatted, but you also
-    don't want comments to span 100+ characters, since that's less
+    with large line lengths, such as 140 in the IntelliJ codebase.
+    Here, you don't want to limit the formatter maximum line width
+    since indented code still needs to be properly formatted, but you
+    also don't want comments to span 100+ characters, since that's less
     readable. Defaults to 72 (or max-line-width, if set lower than 72.)
-  --hanging-indent=<n>
+--hanging-indent=<n>
     Sets the number of spaces to use for hanging indents, e.g. second
     and subsequent lines in a bulleted list or kdoc blog tag.
-  --convert-markup
-    Convert unnecessary HTML tags like &lt; and &gt; into < and >
-  --single-line-comments=<collapse | expand>
+--convert-markup
+     Convert unnecessary HTML tags like < and > into < and >.
+--no-convert-markup
+     Do not convert HTML markup into equivalent KDoc markup.
+--add-punctuation
+    Add missing punctuation, such as a period at the end of a
+    capitalized paragraph.
+--single-line-comments=<collapse | expand>
     With `collapse`, turns multi-line comments into a single line if it
     fits, and with `expand` it will always format commands with /** and
     */ on their own lines. The default is `collapse`.
-  --align-table-columns
-    Reformat tables such that the |column|separators| line up
-  --no-align-table-columns
-    Do not adjust formatting within table cells
-  --order-doc-tags
+--align-table-columns
+     Reformat tables such that the |column|separators| line up
+--no-align-table-columns
+     Do not adjust formatting within table cells
+--order-doc-tags
     Move KDoc tags to the end of comments, and order them in a canonical
     order (@param before @return, and so on)
-  --no-order-doc-tags
-    Do not move or reorder KDoc tagså
-  --overlaps-git-changes=<HEAD | staged>
+--no-order-doc-tags
+     Do not move or reorder KDoc tags
+--overlaps-git-changes=<HEAD | staged>
     If git is on the path, and the command is invoked in a git
-    repository, kdoc-formatter will invoke git to find the changes either
-    in the HEAD commit or in the staged files, and will format only the
-    KDoc comments that overlap these changes.
-  --lines <start:end>, --line <start>
+    repository, kdoc-formatter will invoke git to find the changes
+    either in the HEAD commit or in the staged files, and will format
+    only the KDoc comments that overlap these changes.
+--lines <start:end>, --line <start>
     Line range(s) to format, like 5:10 (1-based; default is all). Can be
     specified multiple times.
-  --greedy
-    Instead of the optimal line breaking normally used by kdoc-formatter,
-    do greedy line breaking instead
-  --dry-run, -n
+--include-md-files
+     Format markdown (*.md) files
+--greedy
+    Instead of the optimal line breaking normally used by
+    kdoc-formatter, do greedy line breaking instead
+--dry-run, -n
     Prints the paths of the files whose contents would change if the
     formatter were run normally.
-  --quiet, -q
-    Quiet mode
-  --help, -help, -h
-    Print this usage statement.
-  @<filename>
-    Read filenames from file.
+--quiet, -q
+     Quiet mode
+--verbose, -v
+     Verbose mode
+--help, -help, -h
+     Print this usage statement.
+@<filename>
+     Read filenames from file.
 
-kdoc-formatter: Version 1.5.4
+kdoc-formatter: Version 1.5.5
 https://github.com/tnorbye/kdoc-formatter
 ```
 
@@ -151,8 +159,8 @@ will be reformatted along with the IDE's other code formatting.
 You can disable this in options, and instead explicitly invoke the
 formatter using Code > Reformat KDoc. You can configure a keyboard
 shortcut if you perform this action frequently (go to Preferences,
-search for Keymap, and then in the Keymap search field look for "KDoc",
-and then double click and choose Add Keyboard Shortcut.
+search for Keymap, and then in the Keymap search field look for
+"KDoc", and then double click and choose Add Keyboard Shortcut.
 
 ![Screenshot](screenshot.png)
 
@@ -169,7 +177,7 @@ buildscript {
         maven { url '/path/to/m2' }
     }
     dependencies {
-        classpath "com.github.tnorbye.kdoc-formatter:kdocformatter:1.5.4"
+        classpath "com.github.tnorbye.kdoc-formatter:kdocformatter:1.5.5"
         // (Sorry about the vanity URL --
         // I tried to get kdoc-formatter:kdoc-formatter:1.3.2 but that
         // didn't meet the naming requirements for publishing:

--- a/cli/src/main/kotlin/kdocformatter/cli/EditorConfigs.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/EditorConfigs.kt
@@ -1,9 +1,8 @@
-package kdocformatter
+package kdocformatter.cli
 
 import java.io.File
-import java.util.Locale
-import kotlin.collections.ArrayList
-import kotlin.collections.HashMap
+import java.util.*
+import kdocformatter.KDocFormattingOptions
 
 /**
  * Basic support for [.editorconfig] files
@@ -168,7 +167,11 @@ object EditorConfigs {
                 }
             }
 
-            getValue("kdoc_formatter_doc_do_not_wrap_if_one_line", "*.kt")?.let { stringValue ->
+            val oneline =
+                getValue("kdoc_formatter_doc_do_not_wrap_if_one_line", "*.kt")
+                    ?: getValue("ij_kotlin_doc_do_not_wrap_if_one_line", "*.kt")
+                        ?: getValue("ij_java_doc_do_not_wrap_if_one_line", "*.java")
+            oneline?.let { stringValue ->
                 if (stringValue == "unset") {
                     EditorConfigs.root?.collapseSingleLine?.let { options.collapseSingleLine = it }
                 } else {
@@ -209,7 +212,13 @@ object EditorConfigs {
                                 .removeSuffix("}")
                                 .split(",")
 
-                        if (globs.any { it == "*" || it == "*.kt" || it == "*.kts" || it == "*.md" }
+                        if (globs.any {
+                                it == "*" ||
+                                    it == "*.kt" ||
+                                    it == "*.kts" ||
+                                    it == "*.md" ||
+                                    it == "*.java"
+                            }
                         ) {
                             map = HashMap()
                             section = SectionMap(line, map)
@@ -232,9 +241,7 @@ object EditorConfigs {
                                 "indent_size",
                                 "tab_width",
                                 "kdoc_formatter_doc_do_not_wrap_if_one_line",
-                                "ij_continuation_indent_size",
-                                "ij_java_doc_do_not_wrap_if_one_line",
-                                "ij_kotlin_align_multiline_parameters" ->
+                                "ij_java_doc_do_not_wrap_if_one_line" ->
                                     if (section != null) {
                                         val value = line.substring(eq + 1).trim()
                                         map[key] = value

--- a/cli/src/main/kotlin/kdocformatter/cli/GitRangeFilter.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/GitRangeFilter.kt
@@ -10,8 +10,8 @@ import java.nio.file.Files
  * these.
  *
  * TODO: Allow specifying an arbitrary range of git sha's. This requires
- *     some work to figure out the correct line numbers
- *     in the current version from older patches.
+ *     some work to figure out the correct line numbers in the current
+ *     version from older patches.
  */
 class GitRangeFilter private constructor(rangeMap: RangeMap) : LineRangeFilter(rangeMap) {
     companion object {

--- a/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormattingOptions.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/KDocFileFormattingOptions.kt
@@ -19,9 +19,18 @@ class KDocFileFormattingOptions {
     var filter = RangeFilter() // default accepts all
     var files = listOf<File>()
     var formattingOptions: KDocFormattingOptions = KDocFormattingOptions()
+    var kdocComments = true
+    var blockComments = false
+    var lineComments = false
     var gitStaged = false
     var gitHead = false
     var includeMd: Boolean = false
+
+    /**
+     * Applies any options explicitly specified via command line options
+     * to the given formatting options.
+     */
+    var overrideOptions: (KDocFormattingOptions) -> Unit = {}
 
     companion object {
         fun parse(args: Array<String>): KDocFileFormattingOptions {
@@ -33,44 +42,59 @@ class KDocFileFormattingOptions {
 
             fun parseInt(s: String): Int = s.toIntOrNull() ?: error("$s is not a number")
 
+            var lineWidth: Int? = null
+            var commentWidth: Int? = null
+            var hangingIndent: Int? = null
+            var collapseSingleLine: Boolean? = null
+            var alignTableColumns: Boolean? = null
+            var convertMarkup: Boolean? = null
+            var addPunctuation: Boolean? = null
+            var optimal: Boolean? = null
+            var orderDocTags: Boolean? = null
+
             while (i < args.size) {
                 val arg = args[i]
                 i++
                 when {
                     arg == "--help" || arg == "-help" || arg == "-h" -> println(usage())
                     arg == "--max-line-width" || arg == "--line-width" || arg == "--right-margin" ->
-                        options.formattingOptions.maxLineWidth = parseInt(args[i++])
+                        lineWidth = parseInt(args[i++])
                     arg.startsWith("--max-line-width=") ->
-                        options.formattingOptions.maxLineWidth =
-                            parseInt(arg.substring("--max-line-width=".length))
-                    arg == "--max-comment-width" ->
-                        options.formattingOptions.maxCommentWidth = parseInt(args[i++])
+                        lineWidth = parseInt(arg.substring("--max-line-width=".length))
+                    arg == "--max-comment-width" -> commentWidth = parseInt(args[i++])
                     arg.startsWith("--max-comment-width=") ->
-                        options.formattingOptions.maxCommentWidth =
-                            parseInt(arg.substring("--max-comment-width=".length))
-                    arg == "--hanging-indent" ->
-                        options.formattingOptions.hangingIndent = parseInt(args[i++])
+                        commentWidth = parseInt(arg.substring("--max-comment-width=".length))
+                    arg == "--hanging-indent" -> hangingIndent = parseInt(args[i++])
                     arg.startsWith("--hanging-indent=") ->
-                        options.formattingOptions.hangingIndent =
-                            parseInt(arg.substring("--hanging-indent=".length))
-                    arg == "--convert-markup" -> options.formattingOptions.convertMarkup = true
-                    arg == "--align-table-columns" ->
-                        options.formattingOptions.alignTableColumns = true
-                    arg == "--no-align-table-columns" ->
-                        options.formattingOptions.alignTableColumns = false
-                    arg == "--order-doc-tags" -> options.formattingOptions.orderDocTags = true
-                    arg == "--no-order-doc-tags" -> options.formattingOptions.orderDocTags = false
-                    arg == "--add-punctuation" -> options.formattingOptions.addPunctuation = true
-                    arg.startsWith("--single-line-comments=collapse") ->
-                        options.formattingOptions.collapseSingleLine = true
-                    arg.startsWith("--single-line-comments=expand") ->
-                        options.formattingOptions.collapseSingleLine = false
+                        hangingIndent = parseInt(arg.substring("--hanging-indent=".length))
+                    arg == "--convert-markup" -> convertMarkup = true
+                    arg == "--no-convert-markup" ||
+                        arg == "--convert-markup=false" ||
+                        arg == "--convert-markup=off" -> convertMarkup = false
+                    arg == "--align-table-columns" -> alignTableColumns = true
+                    arg == "--no-align-table-columns" ||
+                        arg == "--align-table-columns=false" ||
+                        arg == "--align-table-columns=off" -> alignTableColumns = false
+                    arg == "--order-doc-tags" -> orderDocTags = true
+                    arg == "--no-order-doc-tags" ||
+                        arg == "--order-doc-tags=false" ||
+                        arg == "--order-doc-tags=off" -> orderDocTags = false
+                    arg == "--add-punctuation" -> addPunctuation = true
+                    arg.startsWith("--single-line-comments=collapse") ||
+                        arg == "--single-line-comments" -> collapseSingleLine = true
+                    arg.startsWith("--single-line-comments=expand") -> collapseSingleLine = false
                     arg.startsWith("--single-line-comments=") ->
                         error(
                             "Only `collapse` and `expand` are supported for --single-line-comments"
                         )
                     arg == "--overlaps-git-changes=HEAD" -> options.gitHead = true
                     arg == "--overlaps-git-changes=staged" -> options.gitStaged = true
+                    arg == "--include-block-comments" -> options.blockComments = true
+                    arg == "--include-line-comments" -> options.lineComments = true
+                    arg == "--include-kdoc-comments" -> options.kdocComments = true
+                    arg == "--exclude-block-comments" -> options.blockComments = false
+                    arg == "--exclude-line-comments" -> options.lineComments = false
+                    arg == "--exclude-kdoc-comments" -> options.kdocComments = false
                     arg.startsWith("--overlaps-git-changes=") ->
                         error("Only `HEAD` and `staged` are supported for --overlaps-git-changes")
                     arg == "--lines" || arg == "--line" -> rangeLines.add(args[i++])
@@ -82,7 +106,7 @@ class KDocFileFormattingOptions {
                     arg.startsWith("--git-path=") ->
                         options.gitPath = arg.substring("--git-path=".length)
                     arg == "--include-md-files" -> options.includeMd = true
-                    arg == "--greedy" -> options.formattingOptions.optimal = false
+                    arg == "--greedy" -> optimal = false
                     else -> {
                         val paths =
                             if (arg.startsWith("@")) {
@@ -113,8 +137,8 @@ class KDocFileFormattingOptions {
             }
 
             if ((options.gitHead || options.gitStaged) && files.isNotEmpty()) {
-                // Delayed initialization because the git path and the paths to the repository
-                // is typically specified after this flag
+                // Delayed initialization because the git path and the paths to the
+                // repository is typically specified after this flag
                 val filters = mutableListOf<RangeFilter>()
                 if (options.gitHead) {
                     GitRangeFilter.create(options.gitPath, files.first(), false)?.let {
@@ -142,69 +166,136 @@ class KDocFileFormattingOptions {
                 }
             }
 
+            options.overrideOptions =
+                { o ->
+                    lineWidth?.let { o.maxLineWidth = it }
+                    commentWidth?.let { o.maxCommentWidth = it }
+                    collapseSingleLine?.let { o.collapseSingleLine = it }
+                    hangingIndent?.let { o.hangingIndent = it }
+                    alignTableColumns?.let { o.alignTableColumns = it }
+                    convertMarkup?.let { o.convertMarkup = it }
+                    addPunctuation?.let { o.addPunctuation = it }
+                    optimal?.let { o.optimal = it }
+                    orderDocTags?.let { o.orderDocTags = it }
+                }
+            options.overrideOptions(options.formattingOptions)
+
             return options
         }
 
         fun usage(): String {
-            return """
-            Usage: kdoc-formatter [options] file(s)
-            
-            Options:
-              --max-line-width=<n>
-                Sets the length of lines. Defaults to 72. 
-              --max-comment-width=<n>
+            val options =
+                listOf(
+                    "--max-line-width=<n>" to
+                        """
+                Sets the length of lines. Defaults to 72.""",
+                    "--max-comment-width=<n>" to
+                        """
                 Sets the maximum width of comments. This is helpful in a codebase
                 with large line lengths, such as 140 in the IntelliJ codebase. Here,
                 you don't want to limit the formatter maximum line width since
                 indented code still needs to be properly formatted, but you also
                 don't want comments to span 100+ characters, since that's less
                 readable. Defaults to 72 (or max-line-width, if set lower than 72.)
-              --hanging-indent=<n>
+                """,
+                    "--hanging-indent=<n>" to
+                        """
                 Sets the number of spaces to use for hanging indents, e.g. second
-                and subsequent lines in a bulleted list or kdoc blog tag.
-              --convert-markup
-                Convert unnecessary HTML tags like &lt; and &gt; into < and >
-              --add-punctuation
+                and subsequent lines in a bulleted list or kdoc blog tag.""",
+                    "--convert-markup" to
+                        """
+                Convert unnecessary HTML tags like &lt; and &gt; into < and >.""",
+                    "--no-convert-markup" to
+                        """
+                Do not convert HTML markup into equivalent KDoc markup.""",
+                    "--add-punctuation" to
+                        """
                 Add missing punctuation, such as a period at the end of a capitalized
-                paragraph.
-              --single-line-comments=<collapse | expand>
+                paragraph.""",
+                    "--single-line-comments=<collapse | expand>" to
+                        """
                 With `collapse`, turns multi-line comments into a single line if it
                 fits, and with `expand` it will always format commands with /** and
-                */ on their own lines. The default is `collapse`.
-              --align-table-columns
-                Reformat tables such that the |column|separators| line up
-              --no-align-table-columns
-                Do not adjust formatting within table cells
-              --order-doc-tags
+                */ on their own lines. The default is `collapse`.""",
+                    "--align-table-columns" to
+                        """
+                Reformat tables such that the |column|separators| line up""",
+                    "--no-align-table-columns" to
+                        """
+                Do not adjust formatting within table cells""",
+                    "--order-doc-tags" to
+                        """
                 Move KDoc tags to the end of comments, and order them in a canonical
-                order (@param before @return, and so on)
-              --no-order-doc-tags
-                Do not move or reorder KDoc tagså
-              --overlaps-git-changes=<HEAD | staged>
+                order (@param before @return, and so on)""",
+                    "--no-order-doc-tags" to
+                        """
+                Do not move or reorder KDoc tags""",
+                    "--include-block-comments" to
+                        """
+                Format /* block comments */ as well    
+                """,
+                    "--include-line-comments" to
+                        """
+                Format // line comments as well    
+                """,
+                    "--overlaps-git-changes=<HEAD | staged>" to
+                        """
                 If git is on the path, and the command is invoked in a git
                 repository, kdoc-formatter will invoke git to find the changes either
                 in the HEAD commit or in the staged files, and will format only the
-                KDoc comments that overlap these changes.
-              --lines <start:end>, --line <start>
+                KDoc comments that overlap these changes.""",
+                    "--lines <start:end>, --line <start>" to
+                        """
                 Line range(s) to format, like 5:10 (1-based; default is all). Can be
-                specified multiple times.
-              --include-md-files
-                Format markdown (*.md) files
-              --greedy
+                specified multiple times.""",
+                    "--include-md-files" to """
+                Format markdown (*.md) files""",
+                    "--greedy" to
+                        """
                 Instead of the optimal line breaking normally used by kdoc-formatter,
-                do greedy line breaking instead
-              --dry-run, -n
+                do greedy line breaking instead""",
+                    "--dry-run, -n" to
+                        """
                 Prints the paths of the files whose contents would change if the
-                formatter were run normally.
-              --quiet, -q
-                Quiet mode
-              --help, -help, -h
-                Print this usage statement.
-              @<filename>
-                Read filenames from file.
-            
+                formatter were run normally.""",
+                    "--quiet, -q" to """
+                Quiet mode""",
+                    "--verbose, -v" to """
+                Verbose mode""",
+                    "--help, -help, -h" to """
+                Print this usage statement.""",
+                    "@<filename>" to """
+                Read filenames from file."""
+                )
+
+            val fileOptions = KDocFileFormattingOptions()
+            fileOptions.includeMd = true
+            fileOptions.formattingOptions = KDocFormattingOptions(68) // 72 minus 4 for indentation
+            val formatter = KDocFileFormatter(fileOptions)
+
+            val formattedOptions =
+                options.joinToString("\n") {
+                    val (arg, desc) = it
+                    val trimmed = desc.trimIndent().trim()
+                    val source =
+                        formatter.reformatSource(trimmed, ".md").split("\n").joinToString("\n") {
+                            line ->
+                            "    $line"
+                        }
+                    arg + "\n" + source
+                }
+
+            return """
+            Usage: kdoc-formatter [options] file(s)
+
+            Options:
+            """.trimIndent() +
+                "\n" +
+                formattedOptions +
+                "\n\n" +
+                """
             kdoc-formatter: Version ${Version.versionString}
-            https://github.com/tnorbye/kdoc-formatter        
+            https://github.com/tnorbye/kdoc-formatter
             """.trimIndent()
         }
     }

--- a/cli/src/test/kotlin/kdocformatter/cli/EditorConfigsTest.kt
+++ b/cli/src/test/kotlin/kdocformatter/cli/EditorConfigsTest.kt
@@ -1,6 +1,7 @@
-package kdocformatter
+package kdocformatter.cli
 
 import java.io.File
+import kdocformatter.KDocFormattingOptions
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/ide-plugin/CHANGELOG.md
+++ b/ide-plugin/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # KDoc Formatter Plugin Changelog
 
+## [1.5.5]
+- The plugin can now be upgraded without restarting the IDE
+- Improved support for .editorconfig files; these settings will now be
+  reflected immediately (in prior versions you had to restart the IDE
+  because they were improperly cached)
+- Fixed a copy/paste bug which prevented the "Collapse short comments
+  that fit on a single line" option from working.
+- Several formatting related improvements (fixes for
+  bugs #53, #69, #70, #71, #72)
+
 ## [1.5.4]
 - Fix 9 bugs filed by the ktfmt project.
 
@@ -9,26 +19,26 @@
 - @param tags are reordered to match the parameter order in the
   corresponding method signature.
 - There are now options for explicitly specifying the line width and the
-  comment width which overrides the inferred
-  width from code styles or .editorconfig files.
+  comment width which overrides the inferred width from code styles or
+  .editorconfig files.
 - Some reorganization of the options along with updates labels to
   clarify what they mean.
 
 ## [1.5.2]
 - Adds a new option which lets you turn off the concept of a separate
-  maximum comment width from the maximum line width. By
-  default, comments are limited to 72 characters wide (or
-  more accurately the configured width for Markdown files),
-  which leads to more readable text. However, if you really
-  want the full line width to be used, uncheck the "Allow
-  max comment width to be separate from line width" setting.
+  maximum comment width from the maximum line width. By default,
+  comments are limited to 72 characters wide (or more accurately the
+  configured width for Markdown files), which leads to more readable
+  text. However, if you really want the full line width to be used,
+  uncheck the "Allow max comment width to be separate from line width"
+  setting.
 - Fixes bug to ensure the line width and max comment width are properly
   read from the IDE environment settings.
 
 ## [1.5.1]
 - Updated formatter with many bug fixes, as well as improved support for
-  formatting tables as well as reordering KDoc tags. There
-  are new options controlling both of these behaviors.
+  formatting tables as well as reordering KDoc tags. There are new
+  options controlling both of these behaviors.
 - Removed Kotlin logo from the IDE plugin icon
 
 ## [1.4.1]
@@ -37,8 +47,8 @@
 
 ## [1.4.0]
 - The KDoc formatter now participates in regular IDE source code
-  formatting (e.g. Code > Reformat Code).
-  This can be turned off via a setting.
+  formatting (e.g. Code > Reformat Code). This can be turned off via a
+  setting.
 - The markup conversion (if enabled) now converts [] and {@linkplain}
   tags to the KDoc equivalent.
 - Fix bug where preformatted text immediately following a TODO comment
@@ -54,13 +64,13 @@
 
 ## [1.3.1]
 - Fixes a few bugs around markup conversion not producing the right
-  number of blank lines for a <p>, and adds a few more
-  prefixes as non-breakable (e.g. if you have an em
-  dash in your sentence -- like this -- we don't want
-  the "--" to be placed at the beginning of a line.)
+  number of blank lines for a <p>, and adds a few more prefixes as
+  non-breakable (e.g. if you have an em dash in your sentence -- like
+  this -- we don't want the "--" to be placed at the beginning of a
+  line.)
 - Adds an --add-punctuation command line flag and IDE setting to
-  optionally add closing periods on capitalized
-  paragraphs at the end of the comment.
+  optionally add closing periods on capitalized paragraphs at the end of
+  the comment.
 - Special cases TODO: comments (placing them in a block by themselves
   and using hanging indents).
 
@@ -68,16 +78,16 @@
 - Many improves to the markdown handling, such as quoted blocks,
   headers, list continuations, etc.
 - Markup conversion, which until this point could convert inline tags
-  such as **bold** into **bold**, etc, now handles
-  many block level tags too, such as \<p>, \<h1>, etc.
+  such as **bold** into **bold**, etc, now handles many block level tags
+  too, such as \<p>, \<h1>, etc.
 - The IDE plugin can now also reformat line comments under the caret.
   (This is opt-in via options.)
 
 ## [1.2.0]
 - IDE settings panel
 - Ability to alternate formatting between greedy and optimal line
-  breaking when invoked repeatedly (and for short comments,
-  alternating between single line and multiple lines.)
+  breaking when invoked repeatedly (and for short comments, alternating
+  between single line and multiple lines.)
 
 ## [1.1.2]
 - Basic support for <code>.editorconfig</code> files.

--- a/ide-plugin/README.md
+++ b/ide-plugin/README.md
@@ -1,28 +1,22 @@
 # KDoc Formatter Plugin
 
-This plugin setup was based on https://github.com/JetBrains/intellij-platform-plugin-template
+This plugin setup was based on
+https://github.com/JetBrains/intellij-platform-plugin-template
 at revision 7251596f1644f6bb5a7b985e3e8ce0614826eb43.
-
 <!-- Plugin description -->
-This plugin lets you reformat KDoc text -- meaning that it will reformat the
-text and flow the text up to the line width, collapsing comments that
-fit on a single line, indenting text within a block tag, etc.
+This plugin lets you reformat KDoc text -- meaning that it will reformat
+the text and flow the text up to the line width, collapsing comments
+that fit on a single line, indenting text within a block tag, etc.
 
-There are two usage modes. First, it can reformat the current comment
-around the caret position. Open a Kotlin file, navigate to the KDoc
-comment (e.g. <code>/** My Comment */</code>), and then invoke Code | Reformat KDoc.
+By default, it integrates into the IDE's formatting action, so you can
+invoke the formatter (e.g. Code | Reformat Code) and the comments will
+be handled by this plugin.
 
-The second mode lets you reformat all the comments in one or more Kotlin
-source files. For this, navigate to the Projects view and select one or
-more source files, and again invoke Code | Reformat KDoc.
+There's a Settings panel which lets you configure the formatter to
+decide whether you want it to reorder KDoc tags to match the signature
+order, whether to align table columns, whether to convert HTML markup
+into equivalent KDoc markup, etc.
 
 More details about the features can be found at
 [https://github.com/tnorbye/kdoc-formatter#kdoc-formatter](https://github.com/tnorbye/kdoc-formatter#kdoc-formatter).
-
-You can create a shortcut and assign it to this action if you use it
-frequently. On Mac for example, open the Preferences dialog, search for
-Keymap, then in the Keymap search field search for "KDoc", and double click
-on the action to choose "Add Shortcut", then choose the shortcut you want.
-For me, formatting the whole file is assigned to Cmd-Opt-L, so I've assigned
-Reformat KDoc to Cmd-Shift-L.
 <!-- Plugin description end -->

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
@@ -10,27 +10,33 @@ import com.intellij.ui.layout.enableIf
 import com.intellij.ui.layout.panel
 import com.intellij.ui.layout.selected
 import com.intellij.util.ui.UIUtil
-import org.jetbrains.annotations.Nls
 import javax.swing.JSeparator
+import org.jetbrains.annotations.Nls
 
 class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
   @Nls override fun getDisplayName() = "KDoc Formatting"
 
   @Suppress("SpellCheckingInspection") override fun getId() = "kdocformatter.options"
-  private val formatProcessorCheckBox = JBCheckBox("Participate in IDE formatting operations, such as Code > Reformat Code")
+  private val formatProcessorCheckBox =
+      JBCheckBox("Participate in IDE formatting operations, such as Code > Reformat Code")
   private val alternateCheckBox =
-      JBCheckBox("Alternate line breaking algorithms when invoked repeatedly (between greedy and optimal)")
+      JBCheckBox(
+          "Alternate line breaking algorithms when invoked repeatedly (between greedy and optimal)")
   private val collapseLinesCheckBox =
       JBCheckBox("Collapse short comments that fit on a single line")
   private val convertMarkupCheckBox = JBCheckBox("Convert markup like <b>bold</b> into **bold**")
-  private val addPunctuationCheckBox = JBCheckBox("Add missing punctuation, such as a period at the end of a capitalized paragraph")
-  private val lineCommentsCheckBox = JBCheckBox("Allow formatting line comments interactively")
-  private val alignTableColumnsCheckBox = JBCheckBox("Align table columns, ensuring that | separators line up")
-  private val reorderKDocTagsCheckBox = JBCheckBox("Move and reorder KDoc tags to match signature order")
+  private val addPunctuationCheckBox =
+      JBCheckBox("Add missing punctuation, such as a period at the end of a capitalized paragraph")
+  private val lineCommentsCheckBox =
+      JBCheckBox("Allow formatting line comments and block comments interactively")
+  private val alignTableColumnsCheckBox =
+      JBCheckBox("Align table columns, ensuring that | separators line up")
+  private val reorderKDocTagsCheckBox =
+      JBCheckBox("Move and reorder KDoc tags to match signature order")
   private val maxCommentWidthEnabledCheckBox =
-    JBCheckBox("Allow max comment width to be separate from line width")
-  private val overrideLineWidthField = JBTextField("0",4)
-  private val overrideCommentWidthField = JBTextField("0",4)
+      JBCheckBox("Allow max comment width to be separate from line width")
+  private val overrideLineWidthField = JBTextField("0", 4)
+  private val overrideCommentWidthField = JBTextField("0", 4)
 
   private val state = KDocPluginOptions.instance.globalState
 
@@ -54,14 +60,16 @@ class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
     }
     separator()
     row {
-      label("Override line widths (if blank or 0, the code style line width or .editorconfig is used) :")
+      label(
+          "Override line widths (if blank or 0, the code style line width or .editorconfig is used) :")
     }
     row("Line Width") {
       component(overrideLineWidthField).withValidationOnInput { validateWidth(it) }
     }
     row("Comment Width") {
-      component(overrideCommentWidthField).withValidationOnInput { validateWidth(it) }
-    }.enableIf(maxCommentWidthEnabledCheckBox.selected)
+          component(overrideCommentWidthField).withValidationOnInput { validateWidth(it) }
+        }
+        .enableIf(maxCommentWidthEnabledCheckBox.selected)
   }
 
   private fun LayoutBuilder.separator() {

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocPostFormatProcessor.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocPostFormatProcessor.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.refactoring.suggested.startOffset
 import kdocformatter.KDocFormatter
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.psi.KtPsiFactory
@@ -19,12 +18,13 @@ class KDocPostFormatProcessor : PostFormatProcessor {
 
     val kdoc = source as? KDoc ?: return source
 
-    // TODO: Consult options to see whether we want this to participate in formatting
+    // TODO: Consult options to see whether we want this to participate in
+    //     formatting
     val file = source.containingFile
-    val indent = getIndent(file, kdoc.startOffset)
     val original = kdoc.text
-    val options = getKDocFormattingOptions(file, source, false)
-    val formatted = KDocFormatter(options).reformatComment(original, indent)
+    val options = createFormattingOptions(file, source, false)
+    val task = createFormattingTask(source, original, options)
+    val formatted = KDocFormatter(options).reformatComment(task)
     return if (formatted != original) {
       val newComment = KtPsiFactory(source.project).createComment(formatted)
       return source.replace(newComment)

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
@@ -7,9 +7,9 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.vfs.ReadonlyStatusHandler
-import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiComment
@@ -21,19 +21,19 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
-import com.intellij.util.DocumentUtil
 import com.intellij.util.ThrowableRunnable
-import kdocformatter.EditorConfigs
+import kdocformatter.CommentType
+import kdocformatter.FormattingTask
 import kdocformatter.KDocFormatter
 import kdocformatter.KDocFormattingOptions
+import kdocformatter.computeIndents
 import kdocformatter.findSamePosition
+import kdocformatter.isLineComment
 import kotlin.math.min
-import org.jetbrains.annotations.Nullable
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
-import org.jetbrains.kotlin.psi.KtNamedFunction
 
 class ReformatKDocAction : AnAction(), DumbAware {
   override fun actionPerformed(event: AnActionEvent) {
@@ -58,12 +58,15 @@ class ReformatKDocAction : AnAction(), DumbAware {
         startOffset = kdoc.startOffset
         endOffset = kdoc.endOffset
       } else if (KDocPluginOptions.instance.globalState.lineComments && isLineComment(kdoc)) {
-        // We need to collect all contiguous line comments and
-        // replace the whole region.
+        // We need to collect all contiguous line comments and replace the whole
+        // region.
         val comments = getCommentBlock(kdoc)
         startOffset = comments.first().startOffset
         endOffset = comments.last().endOffset
         commentText = getComment(comments)
+      } else if (KDocPluginOptions.instance.globalState.lineComments && isBlockComment(kdoc)) {
+        startOffset = kdoc.startOffset
+        endOffset = kdoc.endOffset
       } else {
         return
       }
@@ -84,9 +87,9 @@ class ReformatKDocAction : AnAction(), DumbAware {
       }
       anchor = newAnchor
 
-      val indent = DocumentUtil.getIndent(document, startOffset)
-      val options = getKDocFormattingOptions(file, kdoc, alternate)
-      val updated = KDocFormatter(options).reformatComment(commentText, indent.toString())
+      val options = createFormattingOptions(file, kdoc, alternate)
+      val task = createFormattingTask(kdoc, commentText, document, startOffset, options)
+      val updated = KDocFormatter(options).reformatComment(task)
       // Attempt to preserve the caret position
       val newDelta = findSamePosition(commentText, oldCaretOffset - startOffset, updated)
       WriteCommandAction.writeCommandAction(project, file)
@@ -126,7 +129,7 @@ class ReformatKDocAction : AnAction(), DumbAware {
         val psiFile = PsiManager.getInstance(project).findFile(file) ?: continue
         val comments =
             PsiTreeUtil.findChildrenOfType(psiFile, PsiComment::class.java)
-                .filter { it is KDoc }
+                .filterIsInstance<KDoc>()
                 .sortedByDescending { it.startOffset }
         if (comments.isEmpty()) {
           continue
@@ -137,16 +140,12 @@ class ReformatKDocAction : AnAction(), DumbAware {
             .run(
                 ThrowableRunnable {
                   for (kdoc in comments) {
-                    if (!(kdoc is KDoc)) {
-                      continue
-                    }
-
                     val commentText = kdoc.text
                     val startOffset = kdoc.startOffset
-                    val indent = DocumentUtil.getIndent(document, startOffset)
-                    val options = getKDocFormattingOptions(psiFile, kdoc, alternate)
-                    val updated =
-                        KDocFormatter(options).reformatComment(commentText, indent.toString())
+                    val options = createFormattingOptions(psiFile, kdoc, alternate)
+                    val task =
+                        createFormattingTask(kdoc, commentText, document, startOffset, options)
+                    val updated = KDocFormatter(options).reformatComment(task)
                     document.replaceString(startOffset, kdoc.endOffset, updated)
                   }
                 })
@@ -188,13 +187,13 @@ class ReformatKDocAction : AnAction(), DumbAware {
     while (curr != null) {
       if (curr is PsiComment) {
         val text = curr.text
-        if (!text.startsWith("//")) {
+        if (!text.isLineComment()) {
           break
         }
         end = curr
       } else if (curr is PsiWhiteSpace) {
-        // Two newlines means there's an empty string in between; we shouldn't
-        // let line comments jump across blank lines
+        // Two newlines means there's an empty string in between; we shouldn't let
+        // line comments jump across blank lines
         val text = curr.text
         val newline = text.indexOf('\n')
         if (newline != -1) {
@@ -240,6 +239,10 @@ class ReformatKDocAction : AnAction(), DumbAware {
     return comment.tokenType == KtTokens.EOL_COMMENT
   }
 
+  private fun isBlockComment(comment: PsiComment): Boolean {
+    return comment.tokenType == KtTokens.BLOCK_COMMENT
+  }
+
   override fun update(event: AnActionEvent) {
     val presentation = event.presentation
     val type = getApplicableCommentType(event)
@@ -253,6 +256,7 @@ class ReformatKDocAction : AnAction(), DumbAware {
         when (type) {
           CommentType.NONE -> return
           CommentType.LINE_COMMENT -> "Reformat Line Comment"
+          CommentType.BLOCK_COMMENT -> "Reformat Block Comment"
           CommentType.KDOC -> "Reformat KDoc"
           CommentType.FILE -> "Reformat KDoc Files"
         }
@@ -260,6 +264,7 @@ class ReformatKDocAction : AnAction(), DumbAware {
 
   private enum class CommentType {
     NONE,
+    BLOCK_COMMENT,
     LINE_COMMENT,
     KDOC,
     FILE
@@ -284,6 +289,8 @@ class ReformatKDocAction : AnAction(), DumbAware {
         return CommentType.KDOC
       } else if (KDocPluginOptions.instance.globalState.lineComments && isLineComment(comment)) {
         return CommentType.LINE_COMMENT
+      } else if (KDocPluginOptions.instance.globalState.lineComments && isBlockComment(comment)) {
+        return CommentType.BLOCK_COMMENT
       }
       return CommentType.NONE
     }
@@ -303,68 +310,108 @@ class ReformatKDocAction : AnAction(), DumbAware {
   }
 }
 
-fun getKDocFormattingOptions(
-    file: @Nullable PsiFile,
-    kdoc: @Nullable PsiComment,
-    alternate: Boolean
-): KDocFormattingOptions {
-  if (EditorConfigs.root == null) {
-    var maxLineWidth = CodeStyle.getLanguageSettings(file, kdoc.language).RIGHT_MARGIN
-    if (maxLineWidth <= 0) {
-      maxLineWidth = CodeStyle.getLanguageSettings(file, KotlinLanguage.INSTANCE).RIGHT_MARGIN
-      if (maxLineWidth <= 0) {
-        maxLineWidth =
-            CodeStyle.getLanguageSettings(file, KotlinLanguage.INSTANCE)
-                .rootSettings
-                .defaultRightMargin
-        if (maxLineWidth <= 0) {
-          maxLineWidth = KDocFormattingOptions().maxLineWidth
-        }
-      }
-    }
-
-    var maxCommentWidth = 0
-    val md = Language.findLanguageByID("Markdown")
-    if (md != null) {
-      maxCommentWidth = CodeStyle.getLanguageSettings(file, md).RIGHT_MARGIN
-    }
-    if (maxCommentWidth <= 0) {
-      maxCommentWidth = KDocFormattingOptions().maxCommentWidth
-    }
-
-    val options =
-        KDocFormattingOptions(maxLineWidth = maxLineWidth, min(maxCommentWidth, maxLineWidth))
-    options.tabWidth = CodeStyle.getIndentOptions(file).TAB_SIZE
-    EditorConfigs.root = options
-  }
-  val virtualFile = file.virtualFile ?: return EditorConfigs.root!!
-  val ioFile = VfsUtilCore.virtualToIoFile(virtualFile)
-  val configOptions = EditorConfigs.getOptions(ioFile).copy()
-  val state = KDocPluginOptions.instance.globalState
-  if (state.collapseSingleLines) {
-    // Not unconditionally assigning such that .editorconfig turning
-    // it on also works (editorconfig always works)
-    configOptions.collapseSpaces = true
-  }
-  configOptions.convertMarkup = state.convertMarkup
-  configOptions.alternate = alternate
-  configOptions.addPunctuation = state.addPunctuation
-  configOptions.alignTableColumns = state.alignTableColumns
-  configOptions.orderDocTags = state.reorderDocTags
-  if (state.reorderDocTags) {
+fun createFormattingTask(
+    kdoc: PsiComment,
+    comment: String,
+    indent: String,
+    secondaryIndent: String,
+    options: KDocFormattingOptions
+): FormattingTask {
+  val task = FormattingTask(options, comment, indent, secondaryIndent)
+  if (task.type == CommentType.KDOC && options.orderDocTags) {
     val parent = kdoc.parent
     if (parent is KtCallableDeclaration) {
-      configOptions.orderedParameterNames = parent.valueParameters.mapNotNull { it.name }.toList()
+      task.orderedParameterNames = parent.valueParameters.mapNotNull { it.name }.toList()
     }
   }
-  if (state.overrideLineWidth > 0) {
-    configOptions.maxLineWidth = state.overrideLineWidth
-  }
-  if (state.overrideCommentWidth > 0) {
-    configOptions.maxCommentWidth = state.overrideCommentWidth
-  }
-  if (!state.maxCommentWidthEnabled) {
-    configOptions.maxCommentWidth = configOptions.maxLineWidth
+
+  return task
+}
+
+fun createFormattingTask(
+    kdoc: PsiComment,
+    comment: String,
+    document: Document,
+    startOffset: Int,
+    options: KDocFormattingOptions
+): FormattingTask {
+  val (indent, secondaryIndent) =
+      computeIndents(startOffset, { offset -> document.charsSequence[offset] }, document.textLength)
+  return createFormattingTask(kdoc, comment, indent, secondaryIndent, options)
+}
+
+fun createFormattingTask(
+    kdoc: PsiComment,
+    comment: String,
+    options: KDocFormattingOptions
+): FormattingTask {
+  val startOffset = kdoc.startOffset
+  val text = kdoc.containingFile.text
+  val (indent, secondaryIndent) =
+      computeIndents(startOffset, { offset -> text[offset] }, text.length)
+  return createFormattingTask(kdoc, comment, indent, secondaryIndent, options)
+}
+
+fun createFormattingOptions(
+    file: PsiFile,
+    kdoc: PsiComment,
+    alternate: Boolean
+): KDocFormattingOptions {
+  var maxLineWidth = getLineWidth(file, kdoc)
+  var maxCommentWidth = getCommentWidth(file)
+
+  val configOptions = KDocFormattingOptions(maxLineWidth, min(maxCommentWidth, maxLineWidth))
+
+  val state = KDocPluginOptions.instance.globalState
+  with(configOptions) {
+    this.alternate = alternate
+    tabWidth = CodeStyle.getIndentOptions(file).TAB_SIZE
+    collapseSingleLine = state.collapseSingleLines
+    convertMarkup = state.convertMarkup
+    addPunctuation = state.addPunctuation
+    alignTableColumns = state.alignTableColumns
+    orderDocTags = state.reorderDocTags
+    if (state.overrideLineWidth > 0) {
+      maxLineWidth = state.overrideLineWidth
+    }
+    if (state.overrideCommentWidth > 0) {
+      maxCommentWidth = state.overrideCommentWidth
+    }
+    if (!state.maxCommentWidthEnabled) {
+      maxCommentWidth = configOptions.maxLineWidth
+    }
   }
   return configOptions
+}
+
+private fun getLineWidth(file: PsiFile, kdoc: PsiComment): Int {
+  val kdocLineWidth = CodeStyle.getLanguageSettings(file, kdoc.language).RIGHT_MARGIN
+  if (kdocLineWidth > 0) {
+    return kdocLineWidth
+  }
+  val kotlinSettings = CodeStyle.getLanguageSettings(file, KotlinLanguage.INSTANCE)
+  val kotlinLineWidth = kotlinSettings.RIGHT_MARGIN
+  if (kotlinLineWidth > 0) {
+    return kotlinLineWidth
+  }
+  val rootLineWidth = kotlinSettings.rootSettings.defaultRightMargin
+  if (rootLineWidth > 0) {
+    return rootLineWidth
+  }
+
+  // Just return the default in kdoc formatter
+  return KDocFormattingOptions().maxLineWidth
+}
+
+private fun getCommentWidth(file: PsiFile): Int {
+  val markdownLanguage = Language.findLanguageByID("Markdown")
+  if (markdownLanguage != null) {
+    val maxCommentWidth = CodeStyle.getLanguageSettings(file, markdownLanguage).RIGHT_MARGIN
+    if (maxCommentWidth > 0) {
+      return maxCommentWidth
+    }
+  }
+
+  // Just return the default in kdoc formatter
+  return KDocFormattingOptions().maxCommentWidth
 }

--- a/ide-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ide-plugin/src/main/resources/META-INF/plugin.xml
@@ -24,10 +24,15 @@
       <add-to-group group-id="CodeFormatGroup" anchor="first"/>
     </action>
 
+    <!-- This adds the formatting action to the file menu. However, this somehow seems to break
+         plugin unloading - see https://github.com/tnorbye/kdoc-formatter/issues/71 - and the custom
+         action is arguably not very useful anymore now that the plugin integrates into the basic
+         formatting machinery of the IDE.
     <group>
     <add-to-group group-id="ProjectViewPopupMenuModifyGroup" anchor="after" relative-to-action="ReformatCode" />
       <reference ref="ReflowKDoc"/>
     </group>
+    -->
   </actions>
 
 </idea-plugin>

--- a/library/src/main/kotlin/kdocformatter/CommentType.kt
+++ b/library/src/main/kotlin/kdocformatter/CommentType.kt
@@ -1,0 +1,51 @@
+package kdocformatter
+
+enum class CommentType(
+    /** The opening string of the comment. */
+    val prefix: String,
+    /** The closing string of the comment. */
+    val suffix: String,
+    /**
+     * For multi line comments, the prefix at each comment line after
+     * the first one.
+     */
+    val linePrefix: String
+) {
+    KDOC("/**", "*/", " * "),
+    BLOCK("/*", "*/", ""),
+    LINE("//", "", "// ");
+
+    /**
+     * The number of characters needed to fit a comment on a line: the
+     * prefix, suffix and a single space padding inside these.
+     */
+    fun singleLineOverhead(): Int {
+        return prefix.length + suffix.length + 1 + if (suffix.isEmpty()) 0 else 1
+    }
+
+    /**
+     * The number of characters required in addition to the line comment
+     * for each line in a multi line comment.
+     */
+    fun lineOverhead(): Int {
+        return linePrefix.length
+    }
+}
+
+fun String.isKDocComment(): Boolean = startsWith("/**")
+
+fun String.isBlockComment(): Boolean = startsWith("/*") && !startsWith("/**")
+
+fun String.isLineComment(): Boolean = startsWith("//")
+
+fun String.commentType(): CommentType {
+    return if (isKDocComment()) {
+        CommentType.KDOC
+    } else if (isBlockComment()) {
+        CommentType.BLOCK
+    } else if (isLineComment()) {
+        CommentType.LINE
+    } else {
+        error("Not a comment: $this")
+    }
+}

--- a/library/src/main/kotlin/kdocformatter/FormattingTask.kt
+++ b/library/src/main/kotlin/kdocformatter/FormattingTask.kt
@@ -1,0 +1,45 @@
+package kdocformatter
+
+class FormattingTask(
+    /** Options to format with */
+    var options: KDocFormattingOptions,
+
+    /** The original comment to be formatted */
+    var comment: String,
+
+    /**
+     * The initial indentation on the first line of the KDoc. The
+     * reformatted comment will prefix each subsequent line with this
+     * string.
+     */
+    var initialIndent: String,
+
+    /**
+     * Indent to use after the first line.
+     *
+     * This is useful when the comment starts the end of an existing
+     * code line. For example, something like this:
+     * ```
+     *     if (foo.bar.baz()) { // This comment started at column 25
+     *         // but the second and subsequent lines are indented 8 spaces
+     *         // ...
+     * ```
+     *
+     * (This doesn't matter much for KDoc comments, since the formatter
+     * will always push these into their own lines so the indents
+     * will match, but for line and block comments it can matter.)
+     */
+    var secondaryIndent: String = initialIndent,
+
+    /**
+     * Optional list of parameters associated with this doc; if set, and
+     * if [KDocFormattingOptions.orderDocTags] is set, parameter doc
+     * tags will be sorted to match this order. (The intent is for the
+     * tool invoking KDocFormatter to pass in the parameter names in
+     * signature order here.)
+     */
+    var orderedParameterNames: List<String> = emptyList(),
+
+    /** The type of comment being formatted. */
+    val type: CommentType = comment.commentType()
+)

--- a/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormattingOptions.kt
@@ -90,13 +90,12 @@ class KDocFormattingOptions(
     var alternate: Boolean = false
 
     /**
-     * Optional list of parameters associated with this doc; if set, and
-     * if [KDocFormattingOptions.orderDocTags] is set, parameter doc
-     * tags will be sorted to match this order. (The intent is for the
-     * tool invoking KDocFormatter to pass in the parameter names in
-     * signature order here.)
+     * KDoc allows param tag to be specified using an alternate bracket
+     * syntax. KDoc formatter ties to unify the format of comments, so
+     * it will rewrite them into the canonical syntax unless this option
+     * is true.
      */
-    var orderedParameterNames: List<String> = emptyList()
+    var allowParamBrackets: Boolean = false
 
     /** Creates a copy of this formatting object. */
     fun copy(): KDocFormattingOptions {
@@ -114,7 +113,6 @@ class KDocFormattingOptions(
         copy.nestedListIndent = nestedListIndent
         copy.optimal = optimal
         copy.alternate = alternate
-        copy.orderedParameterNames = orderedParameterNames
 
         return copy
     }

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.5.4
+buildVersion = 1.5.5

--- a/library/src/test/kotlin/kdocformatter/UtilitiesTest.kt
+++ b/library/src/test/kotlin/kdocformatter/UtilitiesTest.kt
@@ -7,10 +7,6 @@ import org.junit.jupiter.api.Test
 class UtilitiesTest {
     @Test
     fun testFindSamePosition() {
-        fun addCaret(s: String, caret: Int): String {
-            return s.substring(0, caret) + "|" + s.substring(caret)
-        }
-
         fun check(newWithCaret: String, oldWithCaret: String) {
             val oldCaretIndex = oldWithCaret.indexOf('|')
             val newCaretIndex = newWithCaret.indexOf('|')
@@ -78,5 +74,16 @@ class UtilitiesTest {
         check("/** Test End |*/", "/** Test2 End |*/")
         check("/** Test End *|/", "/** Test2 End *|/")
         check("/** Test End */|", "/** Test2 End */|")
+    }
+
+    @Test
+    fun testGetParamName() {
+        assertEquals("foo", "@param foo".getParamName())
+        assertEquals("foo", "@param foo bar".getParamName())
+        assertEquals("foo", "@param foo;".getParamName())
+        assertEquals("foo", "  \t@param\t   foo  bar.".getParamName())
+        assertEquals("foo", "@param[foo]".getParamName())
+        assertEquals("foo", "@param  [foo]".getParamName())
+        assertEquals(null, "@param ".getParamName())
     }
 }


### PR DESCRIPTION
Misc code cleanup (such as a new FormattingTask object which
passes around state for the formatting job, such that it no
longer has to have the hacky parameter order list in the options
class etc).

Plus 1.5.5 work:
- Fixed the following bugs:
   - #53: The collapse-single-line setting does not work in the IDE
   - #69: Paragraph + list (stability), variation 2
   - #70: Multi-line @link isn't converted if there's a #
   - #71: Make plugin dynamic
   - #72: @param with brackets is not supported
   - A bug where `<p>` paragraphs following a blank line would be
     deleted (without leaving a blank paragraph separator)
- Changed heuristics around optimal or greedy line breaking in list
  items and for KDoc tag and TODO-item paragraph formatting.
- The .editorconfig support is improved. It will now pick up the nearest
  applicable .editorconfig settings for a file, but any options
  explicitly set from the command line will override the .editor config.
   - Also, the "collapse documents that fit on a single line" option,
     instead of just defaulting to true, will now use the default
     specified for the equivalent setting for Java (if set), ensuring a
     more consistent codebase. (You can also set it for Kotlin using
     `ij_kotlin_doc_do_not_wrap_if_one_line`, though that option isn't
     supported in the IDE or by the Kotlin plugin currently.)
- Preliminary support for formatting line comments and block comments
  (enabled via new flags, `--include-line-comments` and
  `--include-block-comments`.)
- Misc IDE plugin improvements
- `<pre>` tags are converted into KDoc preformatted blocks