### PR TITLE
1.5.7: Bug fixes (Windows line separators), convert @param references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # KDoc Formatter Changelog
 
+## [1.5.7]
+- Fixed the following bugs:
+   - #76: Preserve newline style (CRLF on Windows)
+   - #77: Preformatting error
+   - #78: Preformatting stability
+   - #79: Replace `{@param name}` with `[name]`
+
 ## [1.5.6]
 - Bugfix: the IDE plugin override line width setting was not working
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Options:
 @<filename>
      Read filenames from file.
 
-kdoc-formatter: Version 1.5.6
+kdoc-formatter: Version 1.5.7
 https://github.com/tnorbye/kdoc-formatter
 ```
 
@@ -177,7 +177,7 @@ buildscript {
         maven { url '/path/to/m2' }
     }
     dependencies {
-        classpath "com.github.tnorbye.kdoc-formatter:kdocformatter:1.5.6"
+        classpath "com.github.tnorbye.kdoc-formatter:kdocformatter:1.5.7"
         // (Sorry about the vanity URL --
         // I tried to get kdoc-formatter:kdoc-formatter:1.3.2 but that
         // didn't meet the naming requirements for publishing:

--- a/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
+++ b/cli/src/test/kotlin/kdocformatter/cli/KDocFileFormatterTest.kt
@@ -186,6 +186,23 @@ class KDocFileFormatterTest {
     }
 
     @Test
+    fun testCrLf() {
+        // https://github.com/tnorbye/kdoc-formatter/issues/76
+        val source =
+            """
+            /**
+             * Sample summary.
+             *
+             * More summary.
+             */
+            """
+                .trimIndent()
+                .replace("\n", "\r\n")
+        val reformatted = reformatFile(source, KDocFormattingOptions(72))
+        assertEquals(source, reformatted)
+    }
+
+    @Test
     fun testLineComment() {
         val source =
             """

--- a/ide-plugin/CHANGELOG.md
+++ b/ide-plugin/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # KDoc Formatter Plugin Changelog
 
+## [1.5.7]
+- Fixed the following bugs:
+  - #76: Preserve newline style (CRLF on Windows)
+  - #77: Preformatting error
+  - #78: Preformatting stability
+  - #79: Replace `{@param name}` with `[name]`
+
 ## [1.5.6]
 - Bugfix: the override line width setting was not working
 

--- a/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
+++ b/library/src/main/kotlin/kdocformatter/KDocFormatter.kt
@@ -122,12 +122,21 @@ class KDocFormatter(private val options: KDocFormattingOptions) {
             sb.removeSuffix(lineSeparator)
         }
 
-        return if (lineComment) {
-            sb.trim().removeSuffix("//").trim().toString()
-        } else if (blockComment) {
-            sb.toString().replace(lineSeparator + "\n", "\n\n")
+        val formatted =
+            if (lineComment) {
+                sb.trim().removeSuffix("//").trim().toString()
+            } else if (blockComment) {
+                sb.toString().replace(lineSeparator + "\n", "\n\n")
+            } else {
+                sb.toString()
+            }
+
+        val separatorIndex = comment.indexOf('\n')
+        return if (separatorIndex > 0 && comment[separatorIndex - 1] == '\r') {
+            // CRLF separator
+            formatted.replace("\n", "\r\n")
         } else {
-            sb.toString()
+            formatted
         }
     }
 

--- a/library/src/main/kotlin/kdocformatter/Paragraph.kt
+++ b/library/src/main/kotlin/kdocformatter/Paragraph.kt
@@ -90,7 +90,7 @@ class Paragraph(private val task: FormattingTask) {
 
         var s = original
         if (options.convertMarkup) {
-            s = convertTags(text)
+            s = convertMarkup(text)
         }
         if (!options.allowParamBrackets) {
             s = rewriteParams(s)
@@ -139,7 +139,7 @@ class Paragraph(private val task: FormattingTask) {
         return s
     }
 
-    private fun convertTags(s: String): String {
+    private fun convertMarkup(s: String): String {
         if (s.none { it == '<' || it == '&' || it == '{' }) return s
 
         val sb = StringBuilder(s.length)
@@ -207,7 +207,18 @@ class Paragraph(private val task: FormattingTask) {
                     continue
                 }
             } else if (c == '{') {
-                if (s.startsWith("@link", i, true)
+                if (s.startsWith("@param", i, true)) {
+                    val curr = i + 6
+                    var end = s.indexOf('}', curr)
+                    if (end == -1) {
+                        end = n
+                    }
+                    sb.append('[')
+                    sb.append(s.substring(curr, end).trim())
+                    sb.append(']')
+                    i = end + 1
+                    continue
+                } else if (s.startsWith("@link", i, true)
                     // @linkplain is similar to @link, but kdoc does *not* render a [symbol]
                     // into a {@linkplain} in HTML, so converting these would change the output.
                     && !s.startsWith("@linkplain", i, true)

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 # Release version definition
-buildVersion = 1.5.6
+buildVersion = 1.5.7

--- a/library/src/test/kotlin/kdocformatter/DokkaVerifier.kt
+++ b/library/src/test/kotlin/kdocformatter/DokkaVerifier.kt
@@ -38,7 +38,7 @@ class DokkaVerifier(private val tempFolder: File) {
     private val PANDOC: String? = null
 
     // JDK install
-    private val JAVA_HOME: String? = System.getenv("JAVA_HOME")
+    private val JAVA_HOME: String? = System.getenv("JAVA_HOME") ?: System.getProperty("java.home")
 
     fun verify(before: String, after: String) {
         JAVA_HOME ?: return


### PR DESCRIPTION
1.5.7 fixes the following bugs:
   - #76: Preserve newline style (CRLF on Windows)
   - #77: Preformatting error
   - #78: Preformatting stability
   - #79: Replace `{@param name}` with `[name]`