### PR TITLE
Add configurable displayName

### DIFF
--- a/ide-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ide-plugin/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,8 @@
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceImplementation="kdocformatter.plugin.KDocPluginOptions"/>
     <applicationConfigurable groupId="editor" groupWeight="112" id="kdocformatter.options"
-                             provider="kdocformatter.plugin.KDocOptionsConfigurableProvider"/>
+                             provider="kdocformatter.plugin.KDocOptionsConfigurableProvider"
+                             displayName="KDoc Formatter" />
     <postFormatProcessor implementation="kdocformatter.plugin.KDocPostFormatProcessor"/>
   </extensions>
 


### PR DESCRIPTION
Add missing `displayName` attribute to the IDE plugin configurable. Fixes #88