### PR TITLE
1.6.2: Update plugin compatibility with 2024.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # KDoc Formatter Changelog
 
+## [1.6.2]
+
+- IDE plugin update only: Compatibility with IntelliJ 2024.1 EAP.
+
 ## [1.6.1]
 - IDE plugin update only.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Options:
 @<filename>
      Read filenames from file.
 
-kdoc-formatter: Version 1.6.1
+kdoc-formatter: Version 1.6.2
 https://github.com/tnorbye/kdoc-formatter
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     apply from: "$rootDir/version.gradle"
 
     ext {
-        gradlePluginVersion = '8.2.0-alpha16'
+        gradlePluginVersion = '8.2.2'
     }
 
     repositories {
@@ -17,8 +17,8 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.0'
-    id 'com.ncorti.ktfmt.gradle' version '0.13.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
+    id 'com.ncorti.ktfmt.gradle' version '0.17.0'
 }
 
 group 'kdocformatter'

--- a/cli/src/main/kotlin/kdocformatter/cli/EditorConfigs.kt
+++ b/cli/src/main/kotlin/kdocformatter/cli/EditorConfigs.kt
@@ -138,7 +138,8 @@ object EditorConfigs {
     private fun computeOptions(): KDocFormattingOptions {
       val options =
           (if (!root) parent?.getOptions()?.copy() else null)
-              ?: EditorConfigs.root?.copy() ?: KDocFormattingOptions()
+              ?: EditorConfigs.root?.copy()
+              ?: KDocFormattingOptions()
 
       getValue("max_line_length", "*.kt")?.let { stringValue ->
         if (stringValue == "unset") {
@@ -175,7 +176,7 @@ object EditorConfigs {
       val oneline =
           getValue("kdoc_formatter_doc_do_not_wrap_if_one_line", "*.kt")
               ?: getValue("ij_kotlin_doc_do_not_wrap_if_one_line", "*.kt")
-                  ?: getValue("ij_java_doc_do_not_wrap_if_one_line", "*.java")
+              ?: getValue("ij_java_doc_do_not_wrap_if_one_line", "*.java")
       oneline?.let { stringValue ->
         if (stringValue == "unset") {
           EditorConfigs.root?.collapseSingleLine?.let { options.collapseSingleLine = it }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     apply from: "$rootDir/../version.gradle"
 
     ext {
-        gradlePluginVersion = '8.2.0-alpha16'
+        gradlePluginVersion = '8.2.2'
     }
 
     repositories {
@@ -17,11 +17,11 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.9.10'
-    id 'com.ncorti.ktfmt.gradle' version '0.13.0'
+    id 'com.gradle.plugin-publish' version '1.2.1'
+    id 'com.ncorti.ktfmt.gradle' version '0.17.0'
 }
 
 // https://issues.sonatype.org/browse/OSSRH-63191

--- a/ide-plugin/CHANGELOG.md
+++ b/ide-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # KDoc Formatter Plugin Changelog
 
+## [1.6.2]
+
+- Compatibility with IntelliJ 2024.1 EAP.
+
 ## [1.6.1]
 
 - Compatibility with IntelliJ 2023.3 EAP.

--- a/ide-plugin/build.gradle.kts
+++ b/ide-plugin/build.gradle.kts
@@ -8,8 +8,8 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
   id("java")
   id("org.jetbrains.kotlin.jvm")
-  id("org.jetbrains.intellij") version "1.15.0"
-  id("org.jetbrains.changelog") version "2.0.0"
+  id("org.jetbrains.intellij") version "1.16.1"
+  id("org.jetbrains.changelog") version "2.2.0"
   id("org.jetbrains.qodana") version "0.1.13"
   id("com.android.lint")
   id("com.ncorti.ktfmt.gradle")

--- a/ide-plugin/gradle.properties
+++ b/ide-plugin/gradle.properties
@@ -7,12 +7,13 @@ pluginRepositoryUrl = https://github.com/tnorbye/kdoc-formatter
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 231
-pluginUntilBuild = 233.*
+pluginSinceBuild = 232
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2023.1
+platformVersion = 2023.2
+#platformVersion = 241.9959-EAP-CANDIDATE-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 platformPlugins = org.jetbrains.kotlin, com.intellij.java, org.intellij.intelliLang

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/KDocOptionsConfigurable.kt
@@ -17,139 +17,116 @@
 package kdocformatter.plugin
 
 import com.intellij.openapi.options.Configurable
-import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SearchableConfigurable
-import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.components.JBTextField
-import com.intellij.ui.layout.LayoutBuilder
-import com.intellij.ui.layout.enableIf
-import com.intellij.ui.layout.panel
-import com.intellij.ui.layout.selected
-import com.intellij.util.ui.UIUtil
-import javax.swing.JSeparator
+import com.intellij.openapi.options.UiDslUnnamedConfigurable
+import com.intellij.openapi.ui.validation.DialogValidation
+import com.intellij.openapi.ui.validation.validationErrorIf
+import com.intellij.ui.dsl.builder.*
+import javax.swing.text.JTextComponent
+import kotlin.reflect.KMutableProperty0
 import org.jetbrains.annotations.Nls
 
-class KDocOptionsConfigurable : SearchableConfigurable, Configurable.NoScroll {
+class KDocOptionsConfigurable :
+    UiDslUnnamedConfigurable.Simple(), SearchableConfigurable, Configurable.NoScroll {
   @Nls override fun getDisplayName() = "KDoc Formatting"
 
   @Suppress("SpellCheckingInspection") override fun getId() = "kdocformatter.options"
 
-  private val formatProcessorCheckBox =
-      JBCheckBox("Participate in IDE formatting operations, such as Code > Reformat Code")
-  private val alternateCheckBox =
-      JBCheckBox(
-          "Alternate line breaking algorithms when invoked repeatedly (between greedy and optimal)")
-  private val collapseLinesCheckBox =
-      JBCheckBox("Collapse short comments that fit on a single line")
-  private val convertMarkupCheckBox = JBCheckBox("Convert markup like <b>bold</b> into **bold**")
-  private val addPunctuationCheckBox =
-      JBCheckBox("Add missing punctuation, such as a period at the end of a capitalized paragraph")
-  private val lineCommentsCheckBox =
-      JBCheckBox("Allow formatting line comments and block comments interactively")
-  private val alignTableColumnsCheckBox =
-      JBCheckBox("Align table columns, ensuring that | separators line up")
-  private val reorderKDocTagsCheckBox =
-      JBCheckBox("Move and reorder KDoc tags to match signature order")
-  private val maxCommentWidthEnabledCheckBox =
-      JBCheckBox("Allow max comment width to be separate from line width")
-  private val overrideLineWidthField = JBTextField("0", 4)
-  private val overrideCommentWidthField = JBTextField("0", 4)
-
   private val state = KDocPluginOptions.instance.globalState
 
-  override fun createComponent() = panel {
-    row { collapseLinesCheckBox() }
-    row { convertMarkupCheckBox() }
-    row { alignTableColumnsCheckBox() }
-    row { reorderKDocTagsCheckBox() }
-    row { addPunctuationCheckBox() }
-    separator()
-    row { formatProcessorCheckBox() }
-    row { alternateCheckBox() }
-    row { lineCommentsCheckBox() }
-    separator()
-    row { maxCommentWidthEnabledCheckBox() }
-    row {
-      label(
-          "When checked, comments will be limited 72 characters (or the configured Markdown line length),\n" +
-              "for improved readability. Otherwise, comments will use the full available line width.",
-          style = UIUtil.ComponentStyle.SMALL)
+  override fun Panel.createContent() {
+    panel {
+      row {
+        checkBox("Collapse short comments that fit on a single line")
+            .bindSelected(state::collapseSingleLines)
+      }
+      row {
+        checkBox("Convert markup like <b>bold</b> into **bold**").bindSelected(state::convertMarkup)
+      }
+      row {
+        checkBox("Align table columns, ensuring that | separators line up")
+            .bindSelected(state::alignTableColumns)
+      }
+      row {
+        checkBox("Move and reorder KDoc tags to match signature order")
+            .bindSelected(state::reorderDocTags)
+      }
+      row {
+        checkBox("Add missing punctuation, such as a period at the end of a capitalized paragraph")
+            .bindSelected(state::addPunctuation)
+      }
+      separator()
+      row {
+        checkBox("Participate in IDE formatting operations, such as Code > Reformat Code")
+            .bindSelected(state::formatProcessor)
+      }
+      row {
+        checkBox(
+                "Alternate line breaking algorithms when invoked repeatedly (between greedy and optimal)")
+            .bindSelected(state::alternateActions)
+      }
+      row {
+        checkBox("Allow formatting line comments and block comments interactively")
+            .bindSelected(state::lineComments)
+      }
+      separator()
+      row {
+        checkBox("Allow max comment width to be separate from line width")
+            .bindSelected(state::maxCommentWidthEnabled)
+      }
+      row {
+        comment(
+            "When checked, comments will be limited 72 characters (or the configured Markdown line length),\n" +
+                "for improved readability. Otherwise, comments will use the full available line width.",
+        )
+      }
+      separator()
+      row {
+        label(
+            "Override line widths (if blank or 0, the code style line width or .editorconfig is used) :")
+      }
+
+      row("Line Width") {
+        // Not using intTextField(range = 10..1000) because we want to allow blanks
+        textField().bindWidth(state::overrideLineWidth).columns(4)
+      }
+
+      row("Comment Width") {
+        textField()
+            .bindWidth(state::overrideCommentWidth)
+            .columns(4)
+            .trimmedTextValidation(widthValidator)
+      }
     }
-    separator()
-    row {
-      label(
-          "Override line widths (if blank or 0, the code style line width or .editorconfig is used) :")
-    }
-    row("Line Width") {
-      component(overrideLineWidthField).withValidationOnInput { validateWidth(it) }
-    }
-    row("Comment Width") {
-          component(overrideCommentWidthField).withValidationOnInput { validateWidth(it) }
-        }
-        .enableIf(maxCommentWidthEnabledCheckBox.selected)
   }
 
-  private fun LayoutBuilder.separator() {
-    row { component(JSeparator()).constraints(growX) }
+  private fun <T : JTextComponent> Cell<T>.bindWidth(prop: KMutableProperty0<Int>): Cell<T> {
+    return bindWidth(prop.toMutableProperty())
   }
 
-  private fun validateWidth(it: JBTextField): Nothing? {
-    val value = it.int
-    if (value != 0 && value !in 10..1000) {
-      error("Invalid line width $value; expected value between 10 and 1000")
-    }
-    return null
+  // Like bindIntText, but treats blank as 0
+  private fun <T : JTextComponent> Cell<T>.bindWidth(prop: MutableProperty<Int>): Cell<T> {
+    return bindText(
+        getter = {
+          val value = prop.get()
+          if (value == 0) "" else value.toString()
+        },
+        setter = { value: String ->
+          if (value.isEmpty()) {
+            prop.set(0)
+          } else {
+            val v = value.toIntOrNull()
+            if (v != null) {
+              prop.set(v)
+            }
+          }
+        })
   }
 
-  /**
-   * Property accessing a text field's value as an integer, with the special support that 0
-   * translates to blank.
-   */
-  private var JBTextField.int: Int
-    get() = text.trim().toIntOrNull()?.coerceAtLeast(0) ?: 0
-    set(value) {
-      text = if (value == 0) "" else value.toString()
-    }
-
-  override fun isModified() =
-      alternateCheckBox.isSelected != state.alternateActions ||
-          collapseLinesCheckBox.isSelected != state.collapseSingleLines ||
-          convertMarkupCheckBox.isSelected != state.convertMarkup ||
-          lineCommentsCheckBox.isSelected != state.lineComments ||
-          addPunctuationCheckBox.isSelected != state.addPunctuation ||
-          formatProcessorCheckBox.isSelected != state.formatProcessor ||
-          alignTableColumnsCheckBox.isSelected != state.alignTableColumns ||
-          reorderKDocTagsCheckBox.isSelected != state.reorderDocTags ||
-          maxCommentWidthEnabledCheckBox.isSelected != state.maxCommentWidthEnabled ||
-          overrideLineWidthField.int != state.overrideLineWidth ||
-          overrideCommentWidthField.int != state.overrideCommentWidth
-
-  @Throws(ConfigurationException::class)
-  override fun apply() {
-    state.alternateActions = alternateCheckBox.isSelected
-    state.collapseSingleLines = collapseLinesCheckBox.isSelected
-    state.convertMarkup = convertMarkupCheckBox.isSelected
-    state.lineComments = lineCommentsCheckBox.isSelected
-    state.addPunctuation = addPunctuationCheckBox.isSelected
-    state.formatProcessor = formatProcessorCheckBox.isSelected
-    state.alignTableColumns = alignTableColumnsCheckBox.isSelected
-    state.reorderDocTags = reorderKDocTagsCheckBox.isSelected
-    state.maxCommentWidthEnabled = maxCommentWidthEnabledCheckBox.isSelected
-    state.overrideLineWidth = overrideLineWidthField.int
-    state.overrideCommentWidth = overrideCommentWidthField.int
-  }
-
-  override fun reset() {
-    alternateCheckBox.isSelected = state.alternateActions
-    collapseLinesCheckBox.isSelected = state.collapseSingleLines
-    convertMarkupCheckBox.isSelected = state.convertMarkup
-    lineCommentsCheckBox.isSelected = state.lineComments
-    addPunctuationCheckBox.isSelected = state.addPunctuation
-    formatProcessorCheckBox.isSelected = state.formatProcessor
-    alignTableColumnsCheckBox.isSelected = state.alignTableColumns
-    reorderKDocTagsCheckBox.isSelected = state.reorderDocTags
-    maxCommentWidthEnabledCheckBox.isSelected = state.maxCommentWidthEnabled
-    overrideLineWidthField.int = state.overrideLineWidth
-    overrideCommentWidthField.int = state.overrideCommentWidth
-  }
+  private val widthValidator: DialogValidation.WithParameter<() -> String> =
+      validationErrorIf<String>("Field must be empty or an integer in the range 10 to 1000") {
+        val value = it
+        value.isNotEmpty() && value.any { digit -> !digit.isDigit() } ||
+            (value.toIntOrNull() == null || value.toInt() < 10)
+      }
 }

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
@@ -25,10 +25,7 @@ import com.facebook.ktfmt.kdoc.findSamePosition
 import com.facebook.ktfmt.kdoc.isLineComment
 import com.intellij.application.options.CodeStyle
 import com.intellij.lang.Language
-import com.intellij.openapi.actionSystem.ActionPlaces
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
@@ -52,6 +49,10 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 
 class ReformatKDocAction : AnAction(), DumbAware {
+  override fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.EDT
+  }
+
   override fun actionPerformed(event: AnActionEvent) {
     val dataContext = event.dataContext
     val project = CommonDataKeys.PROJECT.getData(dataContext) ?: return

--- a/ide-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ide-plugin/src/main/resources/META-INF/plugin.xml
@@ -3,9 +3,6 @@
   <name>Kotlin KDoc Formatter</name>
   <vendor email="tor.norbye@gmail.com" url="https://github.com/tnorbye/kdoc-formatter">Tor Norbye</vendor>
 
-  <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="202.0"/>
-
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->
   <depends>com.intellij.modules.platform</depends>

--- a/library/src/main/kotlin/com/facebook/ktfmt/kdoc/ParagraphListBuilder.kt
+++ b/library/src/main/kotlin/com/facebook/ktfmt/kdoc/ParagraphListBuilder.kt
@@ -232,7 +232,7 @@ class ParagraphListBuilder(
       }
 
       if (lineWithIndentation.startsWith("    ") && // markdown preformatted text
-      (i == 1 || lineContent(lines[i - 2]).isBlank()) && // we've already ++'ed i above
+          (i == 1 || lineContent(lines[i - 2]).isBlank()) && // we've already ++'ed i above
           // Make sure it's not just deeply indented inside a different block
           (paragraph.prev == null ||
               lineWithIndentation.length - lineWithoutIndentation.length >=

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -15,4 +15,4 @@
 #
 
 # Release version definition
-buildVersion = 1.6.1
+buildVersion = 1.6.2


### PR DESCRIPTION
This fixes https://github.com/tnorbye/kdoc-formatter/issues/94 and I also had to rewrite the options UI because it was using an older version of the Option DSL which has been deleted.

(Also updated dependencies, including ktfmt to 0.17 which resulted in some formatting changes.)