### PR TITLE
Version 1.6.7: Fix bugs #105, #106 and fix IDE plugin deprecated usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # KDoc Formatter Changelog
 
+## [1.6.7]
+- Fix issue #104: Include type parameters in parameter list reordering
+- Fix issue #105: Make add punctuation apply to all paragraphs, not just last
+- IDE plugin fixes (replaced deprecated API calls)
+
 ## [1.6.6]
 - IDE-only update: Marked compatible with IntelliJ IDEA 2025.1.
 - Updated dependencies

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Options:
 @<filename>
      Read filenames from file.
 
-kdoc-formatter: Version 1.6.6
+kdoc-formatter: Version 1.6.7
 https://github.com/tnorbye/kdoc-formatter
 ```
 

--- a/ide-plugin/CHANGELOG.md
+++ b/ide-plugin/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # KDoc Formatter Plugin Changelog
 
+## [1.6.7]
+- Updated code to replace deprecated API usages
+- Fix issue #104: Include type parameters in parameter list reordering
+- Fix issue #105: Make add punctuation apply to all paragraphs, not just last
+
 ## [1.6.6]
 - Add support for 2025.1 EAP, and migrate to 2.x version of IntelliJ gradle plugin.
 - Fix https://github.com/tnorbye/kdoc-formatter/issues/106

--- a/ide-plugin/gradle.properties
+++ b/ide-plugin/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/tnorbye/kdoc-formatter
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 232
+pluginSinceBuild = 243
 pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2024.2
+platformVersion = 2024.3
 #platformVersion = 251.14649-EAP-CANDIDATE-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
+++ b/ide-plugin/src/main/kotlin/kdocformatter/plugin/ReformatKDocAction.kt
@@ -25,7 +25,11 @@ import com.facebook.ktfmt.kdoc.findSamePosition
 import com.facebook.ktfmt.kdoc.isLineComment
 import com.intellij.application.options.CodeStyle
 import com.intellij.lang.Language
-import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.actionSystem.ActionUiKind
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
@@ -39,8 +43,8 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.refactoring.suggested.endOffset
-import com.intellij.refactoring.suggested.startOffset
+import com.intellij.psi.util.endOffset
+import com.intellij.psi.util.startOffset
 import com.intellij.util.ThrowableRunnable
 import kotlin.math.min
 import org.jetbrains.kotlin.idea.KotlinLanguage
@@ -263,7 +267,7 @@ class ReformatKDocAction : AnAction(), DumbAware {
     val presentation = event.presentation
     val type = getApplicableCommentType(event)
     val available = type != CommentType.NONE
-    if (ActionPlaces.isPopupPlace(event.place)) {
+    if (event.uiKind == ActionUiKind.POPUP) {
       presentation.isEnabledAndVisible = available
     } else {
       presentation.isEnabled = available
@@ -349,7 +353,9 @@ fun createFormattingTask(
   if (task.type == CommentType.KDOC && options.orderDocTags) {
     val parent = kdoc.parent
     if (parent is KtCallableDeclaration) {
-      task.orderedParameterNames = parent.valueParameters.mapNotNull { it.name }.toList()
+      task.orderedParameterNames =
+          parent.typeParameters.mapNotNull { it.name } +
+              parent.valueParameters.mapNotNull { it.name }
     }
   }
 

--- a/library/src/main/kotlin/com/facebook/ktfmt/kdoc/Utilities.kt
+++ b/library/src/main/kotlin/com/facebook/ktfmt/kdoc/Utilities.kt
@@ -161,7 +161,7 @@ fun String.getParamName(): String? {
     }
   }
 
-  if (start < length && this[start] == '[') {
+  if (start < length && (this[start] == '[' || this[start] == '<')) {
     start++
     while (start < length) {
       if (this[start].isWhitespace()) {

--- a/library/src/main/resources/version.properties
+++ b/library/src/main/resources/version.properties
@@ -15,4 +15,4 @@
 #
 
 # Release version definition
-buildVersion = 1.6.6
+buildVersion = 1.6.7

--- a/library/src/test/kotlin/com/facebook/ktfmt/kdoc/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/com/facebook/ktfmt/kdoc/KDocFormatterTest.kt
@@ -737,6 +737,82 @@ class KDocFormatterTest {
   }
 
   @Test
+  fun testAddPunctuationWithBlocks() {
+    // Regression test for https://github.com/tnorbye/kdoc-formatter/issues/105
+    val source =
+        """
+        /**
+        * This is a test
+        * ```kotlin
+        * println("true")
+        * ```
+        * This is a test
+        */
+        """
+            .trimIndent()
+
+    val options = KDocFormattingOptions(72)
+    options.addPunctuation = true
+    checkFormatter(
+        source,
+        options,
+        """
+        /**
+         * This is a test.
+         *
+         * ```kotlin
+         * println("true")
+         * ```
+         *
+         * This is a test.
+         */
+         """
+            .trimIndent())
+  }
+
+  @Test
+  fun testDoNotPunctuateUrls() {
+    // * Make sure we don't punctuate file paths and URLs
+    // * Do punctuate sentences that end with `
+    val source =
+        """
+      /**
+      * Calling `setCommunicationDevice()` without `clearCommunicationDevice()`
+      *
+      * Creates a [Pattern] corresponding to a [ReplaceString.oldPattern]
+      *
+      * There is more documentation for this tool in lint/docs/internal/document-checks.md.html
+      *
+      * Initial focus is on the subset used and supported by GitHub:
+      * https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/sarif-support-for-code-scanning#supported-sarif-output-file-properties
+      */
+      """
+            .trimIndent()
+
+    val options = KDocFormattingOptions(72)
+    options.addPunctuation = true
+    checkFormatter(
+        source,
+        options,
+        """
+      /**
+       * Calling `setCommunicationDevice()` without
+       * `clearCommunicationDevice()`.
+       *
+       * Creates a [Pattern] corresponding to a
+       * [ReplaceString.oldPattern].
+       *
+       * There is more documentation for this tool in
+       * lint/docs/internal/document-checks.md.html
+       *
+       * Initial focus is on the subset used and supported by GitHub:
+       * https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/sarif-support-for-code-scanning#supported-sarif-output-file-properties
+       */
+       """
+            .trimIndent())
+  }
+
+  @Test
   fun testWrapingOfLinkText() {
     val source =
         """


### PR DESCRIPTION
This CL:
- Updates plugin code to replace deprecated API usages
- Fixes issue #104: Include type parameters in parameter list reordering
- Fixes issue #105: Make add punctuation apply to all paragraphs, not just last

A few other misc improvements (e.g. make punctuation smarter around non-letter paragraph endings, such as `, and avoids adding punctuation on paths and URLs, and also gracefully handle <>'s around type variable names in @param documentation.