### PR TITLE
Fix: Periods not inserted after links

### DIFF
--- a/library/src/main/kotlin/com/facebook/ktfmt/kdoc/ParagraphListBuilder.kt
+++ b/library/src/main/kotlin/com/facebook/ktfmt/kdoc/ParagraphListBuilder.kt
@@ -841,7 +841,7 @@ class ParagraphListBuilder(
         if (c.isWhitespace()) {
           continue
         }
-        val isQuoteEnd = c.isCloseSquareBracket() || c == '`'
+        val isQuoteEnd = c.isCloseSquareBracket() || c == '`' || c == ')'
         if (c.isLetterOrDigit() || isQuoteEnd) {
           if (!isQuoteEnd && isUrlOrPathEnd(text, i)) {
             break

--- a/library/src/test/kotlin/com/facebook/ktfmt/kdoc/KDocFormatterTest.kt
+++ b/library/src/test/kotlin/com/facebook/ktfmt/kdoc/KDocFormatterTest.kt
@@ -134,6 +134,25 @@ class KDocFormatterTest {
   }
 
   @Test
+  fun testPunctuationWithLink() {
+    val source =
+        """
+             /** See [this link](https://example.com) */
+            """
+            .trimIndent()
+
+    val options = KDocFormattingOptions(72)
+    options.addPunctuation = true
+    checkFormatter(
+        source,
+        options,
+        """
+             /** See [this link](https://example.com). */
+            """
+            .trimIndent())
+  }
+
+  @Test
   fun testWithOffset() {
     val source =
         """


### PR DESCRIPTION
This commit fixes an issue where periods were not being inserted at the end of sentences that ended with a markdown link.

The `punctuate` method in `ParagraphListBuilder.kt` was not correctly identifying ')' as a valid sentence-ending character. This commit updates the logic to include ')' in the check, ensuring that periods are correctly added to sentences ending with links.

A new test case has been added to `KDocFormatterTest.kt` to reproduce the issue and verify the fix.