### PR TITLE
Bump until-build to 261

### DIFF
--- a/ide-plugin/gradle.properties
+++ b/ide-plugin/gradle.properties
@@ -8,12 +8,11 @@ pluginRepositoryUrl = https://github.com/tnorbye/kdoc-formatter
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 243
-pluginUntilBuild = 252.*
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-#platformVersion = 2024.3
-platformVersion = 252.21735.32
+platformVersion = 2025.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 platformPlugins = org.jetbrains.kotlin,com.intellij.java,org.intellij.intelliLang


### PR DESCRIPTION
This changes the until-build version to 261 and builds with the newly-stable 253.

Note: this requires a bit more testing